### PR TITLE
decrease verbosity of logging for cached component

### DIFF
--- a/src/YUIComponentCreator.cc
+++ b/src/YUIComponentCreator.cc
@@ -136,7 +136,7 @@ YUIComponentCreator::createInternal( const string & componentName, bool isNamesp
 		uiComponent->setRequestedUIName( name );
 	    }
 
-	    y2milestone( "Returning existing UI component for \"%s\"", name.c_str() );
+	    y2debug( "Returning existing UI component for \"%s\"", name.c_str() );
 	}
 
 	return uiComponent;


### PR DESCRIPTION
Reason is that bindings do not duplicate cache and call repeteadly
for component and it create big mess in log.
