### PR TITLE
fix overloaded method matching

### DIFF
--- a/src/YUINamespace.cc
+++ b/src/YUINamespace.cc
@@ -866,7 +866,12 @@ YUIOverloadedFunction::finishParameters()
     {
 	SymbolEntryPtr se_p = *it;
 	constFunctionTypePtr cand_type = se_p->type();
-	int m = real_tp->match (cand_type);
+        // match direction is slightly confusing here as real_tp can be e.g. any(integer)
+        // that means I want function that accepts integer and return anything
+        // and if there is function that returns integer and accept anything I want it
+        // So I actually want to know if there is candidate that match against proposed type
+        // see FunctionType#match implementation or Type#match documentation
+	int m = cand_type->match (real_tp);
 	y2debug ("Candidate: %s MATCH: %d", se_p->toString().c_str(), m);
 
 	if (m == 0)


### PR DESCRIPTION
this fix contain two parts
1) there was bad return type matching. I found it during testing ruby bindings that benefits from runtime decision about overloaded function
2) second part why it start working is related fix in core that fix function type matching - https://github.com/yast/yast-core/commit/7fb894662dba29389bc553ee3ffdbac9b688826d

Please merge this fix after M2 and M2 with ruby is released because my previous fix in core that fix this issue was wrong but keeps ruby version working.
Thanks
