### PR TITLE
fix calling SetFunctionKeys as overloaded function (gh#yast/ycp-killer#5...

### DIFF
--- a/src/YUINamespace.h
+++ b/src/YUINamespace.h
@@ -295,7 +295,7 @@ public:
     /* TYPEINFO: string (string, string, string) */
     YCPValue AskForSaveFileName( const YCPString & startWith, const YCPString & filter, const YCPString & headline );
 
-    /* TYPEINFO: void (map<string,integer>) */
+    /* TYPEINFO: void (map<any,any>) */
     YCPValue SetFunctionKeys( const YCPMap & new_fkeys );
 
     /* TYPEINFO: any (string, string, string) */


### PR DESCRIPTION
...56)

for reference see https://github.com/yast/ycp-killer/issues/556
