### PR TITLE
more relaxed typeinfo, avoding problem when calling from Ruby code

### DIFF
--- a/package/yast2-ycp-ui-bindings.changes
+++ b/package/yast2-ycp-ui-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Mar 12 08:19:36 UTC 2014 - jsrain@suse.cz
+
+- more relaxed typeinfo to avoid errors when calling the builtin
+- 3.1.5
+
+-------------------------------------------------------------------
 Mon Dec  9 08:28:31 UTC 2013 - lslezak@suse.cz
 
 - added missing locale directory initialization, fixes missing

--- a/package/yast2-ycp-ui-bindings.spec
+++ b/package/yast2-ycp-ui-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ycp-ui-bindings
-Version:        3.1.4
+Version:        3.1.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/source/YUINamespace.h
+++ b/source/YUINamespace.h
@@ -313,7 +313,7 @@ public:
     /* TYPEINFO: boolean (term) */	
     YCPBoolean OpenContextMenu( const YCPTerm & term );
 
-    /* TYPEINFO: void (map<string,string>) */
+    /* TYPEINFO: void (map<any,any>) */
     YCPValue SetReleaseNotes( const YCPMap & relnotes );
 
 


### PR DESCRIPTION
Note that this is necessary, otherwise the ruby bindings report error in type mismatch
