### PR TITLE
Add new ItemSelector to the UI Interpreter

### DIFF
--- a/examples/Events.rb
+++ b/examples/Events.rb
@@ -62,7 +62,7 @@ module Yast
           Item(Id(:napoli), "Napoli"),
           Item(Id(:funghi), "Funghi"),
           Item(Id(:salami), "Salami"),
-          Item(Id(:prociutto), "Prosciutto"),
+          Item(Id(:prosciutto), "Prosciutto"),
           Item(Id(:stagioni), "Quattro Stagioni (a pizza devided into 4 parts)"),
           Item(Id(:chef), "A la Chef", true)
         ]

--- a/examples/ItemSelector1.rb
+++ b/examples/ItemSelector1.rb
@@ -1,0 +1,224 @@
+# encoding: utf-8
+
+module Yast
+  # This is a comprehensive example for both ItemSelector widgets, the
+  # SingleItemSelector and the MultiItemSelector. It showcases most of the
+  # features of ItemSelector widgets.
+  #
+  # For much simpler examples, see
+  #
+  #   - ItemSelector2-minimalistic.rb
+  #   - SingleItemSelector1.rb
+  #   - MultiItemSelector1.rb
+  #
+  # This example starts with a pop-up dialog asking for some config values (see
+  # below) such as which selection mode to use (single or multi), the notify
+  # mode and the number of initially visible items.
+  #
+  # Then the main dialog opens with those settings applied. Select or deselect
+  # items and watch the results fields (if notify mode was selected) or click
+  # the respective buttons.
+  #
+  # After the main dialog is closed, a final pop-up dialog shows the results.
+  #
+  # This example also shows how to break down UI operation into smaller, better
+  # manageable parts.
+  #
+  class ExampleClient < Client
+    Yast.import "UI"
+
+    def initialize
+      @notify = true
+      @single_selection = false
+      @visible_items = 4
+    end
+
+    def items
+      [
+        Item(Id(:margherita),   "Pizza Margherita",       "Very basic with just tomatoes and cheese"),
+        Item(Id(:cappricciosa), "Pizza Capricciosa",      "Ham and vegetables"                      ),
+        Item(Id(:funghi),       "Pizza Funghi",           "Mushrooms"                               ),
+        Item(Id(:prosciutto),   "Pizza Prosciutto",       "Ham"                                     ),
+        Item(Id(:quattro),      "Pizza Quattro Stagioni", "Different toppings in each quarter"      ),
+        Item(Id(:calzone),      "Calzone",                "Folded over"                             )
+      ].freeze
+    end
+
+    def item_selector
+      args = [Id(:pizza)]
+      args << Opt(:notify) if @notify
+      args << items
+
+      if @single_selection
+        SingleItemSelector(*args)
+      else
+        MultiItemSelector(*args)
+      end
+    end
+
+    def main_dialog
+      MarginBox(2, 0.4,
+        VBox(
+          Heading("Pizza Menu"),
+          VSpacing(0.2),
+          item_selector,
+          VSpacing(0.4),
+          HBox(
+            Label(Id(:value_field), Opt(:outputField, :hstretch), "<unknown>"),
+            PushButton(Id(:value_button), "&Value")
+          ),
+          VSpacing(0.3),
+          HBox(
+            Label(Id(:result_field), Opt(:outputField, :hstretch), "<selected items>\n\n\n\n\n"),
+            PushButton(Id(:result_button), "&Result")
+          ),
+          VSpacing(0.3),
+          Right(
+            PushButton(Id(:close), "&Close")
+          )
+        )
+      )
+    end
+
+    def set_visible_items
+      UI.ChangeWidget(:pizza, :VisibleItems, @visible_items)
+      UI.RecalcLayout # needed for the change to have an effect
+    end
+
+    def init_main_dialog
+      set_visible_items
+      UI.ChangeWidget(:value_button, :Enabled, !@notify)
+      UI.ChangeWidget(:result_button, :Enabled, !@notify)
+    end
+
+    def update_value
+      # :Value returns the ID of the first selected item
+      value = UI.QueryWidget(:pizza, :Value)
+      UI.ChangeWidget(:value_field, :Value, value.to_s)
+    end
+
+    def update_result
+      selected = UI.QueryWidget(:pizza, :SelectedItems)
+
+      # SelectedItems returns an array of IDs, i.e. in our case symbols:
+      # [:funghi, :calzone]
+      # Convert each of them to string and join them into multiple lines.
+      result = selected.map(&:to_s).join(",\n")
+      UI.ChangeWidget(:result_field, :Value, result)
+    end
+
+    def handle_events
+      while true
+        widget = UI.UserInput
+        case widget
+
+        when :close, :cancel # :cancel is WM_CLOSE
+          break # leave event loop
+
+        when :value_button
+          update_value
+
+        when :result_button
+          update_result
+
+        when :pizza # this will happen only if Opt(:notify) is set
+          update_value
+          update_result
+
+        end
+      end
+      widget
+    end
+
+    # Ask the user some configuration values for the main dialog.
+    #
+    #    +---------------------------+
+    #    |   Program Configuration   |
+    #    |                           |
+    #    |  Selection Mode           |
+    #    |  (x) Single Selection     |
+    #    |  ( ) Multi-Selection      |
+    #    |                           |
+    #    |  [x] Notify               |
+    #    |                           |
+    #    |  Visible Items:           |
+    #    |  [ 4          ]           |
+    #    |                           |
+    #    |   [Continue]  [Cancel]    |
+    #    +---------------------------+
+    def ask_config_values
+      UI.OpenDialog(
+        MarginBox( 2, 0.4,
+          VBox(
+            Heading("Program Configuration"),
+            VSpacing(0.2),
+            Left(
+              RadioButtonGroup(
+                Frame("Selection Mode",
+                  VBox(
+                    Left(RadioButton(Id(:single_selection), "&Single Selection", @single_selection)),
+                    Left(RadioButton(Id(:multi_selection), "&Multi-Selection", !@single_selection))
+                  )
+                )
+              )
+            ),
+            VSpacing(0.6),
+            Left(CheckBox(Id(:notify), "&Notify", @notify)),
+            VSpacing(0.6),
+            Left(IntField(Id(:visible_items), "&Visible Items:", 1, 10, @visible_items)),
+            VSpacing(1),
+            ButtonBox(
+              PushButton(Id(:continue), "C&ontinue"),
+              PushButton(Id(:cancel), "&Cancel")
+            )
+          )
+        )
+      )
+
+      widget = UI.UserInput
+      @notify = UI.QueryWidget(:notify, :Value)
+      @single_selection = UI.QueryWidget(:single_selection, :Value)
+      @visible_items = UI.QueryWidget(:visible_items, :Value)
+      UI.CloseDialog
+      widget
+    end
+
+    # Show the result in a pop-up dialog
+    def show_result(result)
+      UI.OpenDialog(
+        VBox(
+          Label("Selected:\n\n#{result}"),
+          PushButton("&OK")
+        )
+      )
+      UI.UserInput
+      UI.CloseDialog
+    end
+
+    def main
+      widget = ask_config_values
+      return if widget == :cancel
+
+      UI.OpenDialog(main_dialog)
+      init_main_dialog
+      handle_events
+
+      # Fetch the result as long as the widget still exists, i.e. BEFORE UI.CloseDialog
+      # For a SingleItemSelector, use :Value (i.e. the first selected item);
+      # for a MultiItemSelector,  use :SelectedItems
+      #
+      # :SelectedItems returns an array of the the ID (or the label string if
+      # there is no ID) of each selected item, not the complete item.
+
+      result = UI.QueryWidget(:pizza, :SelectedItems)
+      UI.CloseDialog
+
+      result = result.map(&:to_s).join(",\n")
+      show_result(result)
+
+      nil
+    end
+  end
+end
+
+Yast::ExampleClient.new.main

--- a/examples/ItemSelector2-minimalistic.rb
+++ b/examples/ItemSelector2-minimalistic.rb
@@ -1,0 +1,53 @@
+# encoding: utf-8
+
+module Yast
+  class ExampleClient < Client
+    def main
+      Yast.import "UI"
+
+      UI.OpenDialog(
+        VBox(
+          SingleItemSelector(
+           Id(:pizza),
+           [
+             # Notice no item IDs, so we'll get the item label as the result.
+             # Even the descriptions are optional.
+             Item("Pizza Margherita",       "Very basic with just tomatoes and cheese"),
+             Item("Pizza Capricciosa",      "Ham and vegetables"                      ),
+             Item("Pizza Funghi",           "Mushrooms"                               ),
+             Item("Pizza Prosciutto",       "Ham"                                     ),
+             Item("Pizza Quattro Stagioni", "Different toppings in each quarter"      ),
+             Item("Calzone",                "Folded over"                             )
+           ]
+          ),
+          PushButton("&OK")
+        )
+      )
+      UI.UserInput
+
+      # Fetch the result as long as the widget still exists, i.e. BEFORE UI.CloseDialog
+      # For a SingleItemSelector, use :Value (i.e. the first selected item);
+      # for a MultiItemSelector,  use :SelectedItems
+      #
+      # :SelectedItems returns an array of the the ID (or the label string if
+      # there is no ID) of each selected item, not the complete item.
+
+      result = UI.QueryWidget(:pizza, :Value)
+      UI.CloseDialog
+
+      # Show the result in a pop-up dialog
+      UI.OpenDialog(
+        VBox(
+          Label("Selected:\n#{result}"),
+          PushButton("&OK")
+        )
+      )
+      UI.UserInput
+      UI.CloseDialog
+
+      nil
+    end
+  end
+end
+
+Yast::ExampleClient.new.main

--- a/examples/MultiItemSelector1.rb
+++ b/examples/MultiItemSelector1.rb
@@ -1,0 +1,46 @@
+# encoding: utf-8
+
+module Yast
+  class ExampleClient < Client
+    def main
+      Yast.import "UI"
+
+      UI.OpenDialog(
+        VBox(
+          MultiItemSelector(
+           Id(:pizza),
+           [
+             Item(Id(:margherita),   "Pizza Margherita",       "Very basic with just tomatoes and cheese"),
+             Item(Id(:cappricciosa), "Pizza Capricciosa",      "Ham and vegetables"                      ),
+             Item(Id(:funghi),       "Pizza Funghi",           "Mushrooms"                               ),
+             Item(Id(:prosciutto),   "Pizza Prosciutto",       "Ham"                                     ),
+             Item(Id(:quattro),      "Pizza Quattro Stagioni", "Different toppings in each quarter"      ),
+             Item(Id(:calzone),      "Calzone",                "Folded over"                             )
+           ]
+          ),
+          PushButton("&OK")
+        )
+      )
+      UI.UserInput
+      selected = UI.QueryWidget(:pizza, :SelectedItems)
+      UI.CloseDialog
+
+      # Show result in pop-up dialog
+      result = selected.join(", ")
+      result = "<nothing>" if result.empty?
+      
+      UI.OpenDialog(
+        VBox(
+          Label("Selected:\n#{result}"),
+          PushButton("&OK")
+        )
+      )
+      UI.UserInput
+      UI.CloseDialog
+
+      nil
+    end
+  end
+end
+
+Yast::ExampleClient.new.main

--- a/examples/SingleItemSelector1.rb
+++ b/examples/SingleItemSelector1.rb
@@ -1,0 +1,43 @@
+# encoding: utf-8
+
+module Yast
+  class ExampleClient < Client
+    def main
+      Yast.import "UI"
+
+      UI.OpenDialog(
+        VBox(
+          SingleItemSelector(
+           Id(:pizza),
+           [
+             Item(Id(:margherita),   "Pizza Margherita",       "Very basic with just tomatoes and cheese"),
+             Item(Id(:cappricciosa), "Pizza Capricciosa",      "Ham and vegetables"                      ),
+             Item(Id(:funghi),       "Pizza Funghi",           "Mushrooms"                               ),
+             Item(Id(:prosciutto),   "Pizza Prosciutto",       "Ham"                                     ),
+             Item(Id(:quattro),      "Pizza Quattro Stagioni", "Different toppings in each quarter"      ),
+             Item(Id(:calzone),      "Calzone",                "Folded over"                             )
+           ]
+          ),
+          PushButton("&OK")
+        )
+      )
+      UI.UserInput
+      result = UI.QueryWidget(:pizza, :Value)
+      UI.CloseDialog
+
+      # Show result in pop-up dialog
+      UI.OpenDialog(
+        VBox(
+          Label("Selected:\n#{result}"),
+          PushButton("&OK")
+        )
+      )
+      UI.UserInput
+      UI.CloseDialog
+
+      nil
+    end
+  end
+end
+
+Yast::ExampleClient.new.main

--- a/examples/WaitForEvent.rb
+++ b/examples/WaitForEvent.rb
@@ -24,7 +24,7 @@ module Yast
               Item(Id(:napoli), "Napoli"),
               Item(Id(:funghi), "Funghi"),
               Item(Id(:salami), "Salami"),
-              Item(Id(:prociutto), "Prosciutto"),
+              Item(Id(:prosciutto), "Prosciutto"),
               Item(Id(:stagioni), "Quattro Stagioni"),
               Item(Id(:chef), "A la Chef", true)
             ]

--- a/package/yast2-ycp-ui-bindings.changes
+++ b/package/yast2-ycp-ui-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Sep 23 12:39:31 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Added ItemSelector widget (bsc#1084674)
+- 4.2.2
+
+-------------------------------------------------------------------
 Fri Sep 13 15:05:16 CEST 2019 - aschnell@suse.com
 
 - added example using scrollbar positions of RichText widget with

--- a/package/yast2-ycp-ui-bindings.spec
+++ b/package/yast2-ycp-ui-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ycp-ui-bindings
-Version:        4.2.1
+Version:        4.2.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -38,8 +38,8 @@ BuildRequires:	sgml-skel
 Requires:	yast2-core
 BuildRequires:	yast2-core-devel
 
-# YApplication::openUI/closeUI
-BuildRequires:	libyui-devel >= 3.2.0
+# YWidgetFactory::createSingleItemSelector()
+BuildRequires:	libyui-devel >= 3.8.0
 
 # libyui ImplPtr
 BuildRequires:	boost-devel

--- a/src/YCPDialogParser.cc
+++ b/src/YCPDialogParser.cc
@@ -2,6 +2,7 @@
 /****************************************************************************
 
 Copyright (c) 2000 - 2010 Novell, Inc.
+Copyright (c) 2019 SUSE LLC
 All Rights Reserved.
 
 This program is free software; you can redistribute it and/or
@@ -21,9 +22,9 @@ you may find current contact information at www.novell.com
 
 ****************************************************************************
 
-  File:		YUI_widgets.cc
+  File:		YCPDialogParser.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 
@@ -64,6 +65,7 @@ you may find current contact information at www.novell.com
 
 #include <yui/YAlignment.h>
 #include <yui/YBarGraph.h>
+#include <yui/YBusyIndicator.h>
 #include <yui/YButtonBox.h>
 #include <yui/YCheckBox.h>
 #include <yui/YCheckBoxFrame.h>
@@ -73,6 +75,7 @@ you may find current contact information at www.novell.com
 #include <yui/YDumbTab.h>
 #include <yui/YEmpty.h>
 #include <yui/YFrame.h>
+#include <yui/YGraph.h>
 #include <yui/YImage.h>
 #include <yui/YInputField.h>
 #include <yui/YIntField.h>
@@ -97,11 +100,9 @@ you may find current contact information at www.novell.com
 #include <yui/YSquash.h>
 #include <yui/YTable.h>
 #include <yui/YTimeField.h>
+#include <yui/YTimezoneSelector.h>
 #include <yui/YTree.h>
 #include <yui/YWizard.h>
-#include <yui/YTimezoneSelector.h>
-#include <yui/YGraph.h>
-#include <yui/YBusyIndicator.h>
 
 using std::string;
 
@@ -203,40 +204,40 @@ YCPDialogParser::parseWidgetTreeTerm( YWidget *		p,
 	if ( rawopt->value(o)->isSymbol() )
 	{
 	    string sym = rawopt->value(o)->asSymbol()->symbol();
-	    if	    ( sym == YUIOpt_notify	) opt.notifyMode.setValue( true );
-	    else if ( sym == YUIOpt_notifyContextMenu) opt.notifyContextMenu.setValue( true );
-	    else if ( sym == YUIOpt_disabled	) opt.isDisabled.setValue( true );
-	    else if ( sym == YUIOpt_hstretch	) opt.isHStretchable.setValue( true );
-	    else if ( sym == YUIOpt_vstretch	) opt.isVStretchable.setValue( true );
-	    else if ( sym == YUIOpt_hvstretch	) { opt.isHStretchable.setValue( true ); opt.isVStretchable.setValue( true ); }
-	    else if ( sym == YUIOpt_autoShortcut ) opt.autoShortcut.setValue( true );
-	    else if ( sym == YUIOpt_boldFont	) opt.boldFont.setValue( true );
-	    else if ( sym == YUIOpt_keyEvents	) opt.keyEvents.setValue( true );
-	    else if ( sym == YUIOpt_key_F1	) opt.key_Fxx.setValue(	 1 );
-	    else if ( sym == YUIOpt_key_F2	) opt.key_Fxx.setValue(	 2 );
-	    else if ( sym == YUIOpt_key_F3	) opt.key_Fxx.setValue(	 3 );
-	    else if ( sym == YUIOpt_key_F4	) opt.key_Fxx.setValue(	 4 );
-	    else if ( sym == YUIOpt_key_F5	) opt.key_Fxx.setValue(	 5 );
-	    else if ( sym == YUIOpt_key_F6	) opt.key_Fxx.setValue(	 6 );
-	    else if ( sym == YUIOpt_key_F7	) opt.key_Fxx.setValue(	 7 );
-	    else if ( sym == YUIOpt_key_F8	) opt.key_Fxx.setValue(	 8 );
-	    else if ( sym == YUIOpt_key_F9	) opt.key_Fxx.setValue(	 9 );
-	    else if ( sym == YUIOpt_key_F10	) opt.key_Fxx.setValue( 10 );
-	    else if ( sym == YUIOpt_key_F11	) opt.key_Fxx.setValue( 11 );
-	    else if ( sym == YUIOpt_key_F12	) opt.key_Fxx.setValue( 12 );
-	    else if ( sym == YUIOpt_key_F13	) opt.key_Fxx.setValue( 13 );
-	    else if ( sym == YUIOpt_key_F14	) opt.key_Fxx.setValue( 14 );
-	    else if ( sym == YUIOpt_key_F15	) opt.key_Fxx.setValue( 15 );
-	    else if ( sym == YUIOpt_key_F16	) opt.key_Fxx.setValue( 16 );
-	    else if ( sym == YUIOpt_key_F17	) opt.key_Fxx.setValue( 17 );
-	    else if ( sym == YUIOpt_key_F18	) opt.key_Fxx.setValue( 18 );
-	    else if ( sym == YUIOpt_key_F19	) opt.key_Fxx.setValue( 19 );
-	    else if ( sym == YUIOpt_key_F20	) opt.key_Fxx.setValue( 20 );
-	    else if ( sym == YUIOpt_key_F21	) opt.key_Fxx.setValue( 21 );
-	    else if ( sym == YUIOpt_key_F22	) opt.key_Fxx.setValue( 22 );
-	    else if ( sym == YUIOpt_key_F23	) opt.key_Fxx.setValue( 23 );
-	    else if ( sym == YUIOpt_key_F24	) opt.key_Fxx.setValue( 24 );
-	    else if ( sym == YUIOpt_key_none	) opt.key_Fxx.setValue( -1 );
+	    if	    ( sym == YUIOpt_notify              )  opt.notifyMode.setValue( true );
+	    else if ( sym == YUIOpt_notifyContextMenu   )  opt.notifyContextMenu.setValue( true );
+	    else if ( sym == YUIOpt_disabled	        )  opt.isDisabled.setValue( true );
+	    else if ( sym == YUIOpt_hstretch	        )  opt.isHStretchable.setValue( true );
+	    else if ( sym == YUIOpt_vstretch	        )  opt.isVStretchable.setValue( true );
+	    else if ( sym == YUIOpt_hvstretch	        )  { opt.isHStretchable.setValue( true ); opt.isVStretchable.setValue( true ); }
+	    else if ( sym == YUIOpt_autoShortcut        )  opt.autoShortcut.setValue( true );
+	    else if ( sym == YUIOpt_boldFont	        )  opt.boldFont.setValue( true );
+	    else if ( sym == YUIOpt_keyEvents	        )  opt.keyEvents.setValue( true );
+	    else if ( sym == YUIOpt_key_F1	        )  opt.key_Fxx.setValue(  1 );
+	    else if ( sym == YUIOpt_key_F2	        )  opt.key_Fxx.setValue(  2 );
+	    else if ( sym == YUIOpt_key_F3	        )  opt.key_Fxx.setValue(  3 );
+	    else if ( sym == YUIOpt_key_F4	        )  opt.key_Fxx.setValue(  4 );
+	    else if ( sym == YUIOpt_key_F5	        )  opt.key_Fxx.setValue(  5 );
+	    else if ( sym == YUIOpt_key_F6	        )  opt.key_Fxx.setValue(  6 );
+	    else if ( sym == YUIOpt_key_F7	        )  opt.key_Fxx.setValue(  7 );
+	    else if ( sym == YUIOpt_key_F8	        )  opt.key_Fxx.setValue(  8 );
+	    else if ( sym == YUIOpt_key_F9	        )  opt.key_Fxx.setValue(  9 );
+	    else if ( sym == YUIOpt_key_F10	        )  opt.key_Fxx.setValue( 10 );
+	    else if ( sym == YUIOpt_key_F11	        )  opt.key_Fxx.setValue( 11 );
+	    else if ( sym == YUIOpt_key_F12	        )  opt.key_Fxx.setValue( 12 );
+	    else if ( sym == YUIOpt_key_F13	        )  opt.key_Fxx.setValue( 13 );
+	    else if ( sym == YUIOpt_key_F14	        )  opt.key_Fxx.setValue( 14 );
+	    else if ( sym == YUIOpt_key_F15	        )  opt.key_Fxx.setValue( 15 );
+	    else if ( sym == YUIOpt_key_F16	        )  opt.key_Fxx.setValue( 16 );
+	    else if ( sym == YUIOpt_key_F17	        )  opt.key_Fxx.setValue( 17 );
+	    else if ( sym == YUIOpt_key_F18	        )  opt.key_Fxx.setValue( 18 );
+	    else if ( sym == YUIOpt_key_F19	        )  opt.key_Fxx.setValue( 19 );
+	    else if ( sym == YUIOpt_key_F20	        )  opt.key_Fxx.setValue( 20 );
+	    else if ( sym == YUIOpt_key_F21	        )  opt.key_Fxx.setValue( 21 );
+	    else if ( sym == YUIOpt_key_F22	        )  opt.key_Fxx.setValue( 22 );
+	    else if ( sym == YUIOpt_key_F23	        )  opt.key_Fxx.setValue( 23 );
+	    else if ( sym == YUIOpt_key_F24	        )  opt.key_Fxx.setValue( 24 );
+	    else if ( sym == YUIOpt_key_none	        )  opt.key_Fxx.setValue( -1 );
 	    else ol->add( rawopt->value(o) );
 	}
 	else if ( ! rawopt->value(o)->isTerm() )
@@ -255,7 +256,8 @@ YCPDialogParser::parseWidgetTreeTerm( YWidget *		p,
     YWidget * w	= 0;
     string    s	= term->name();
 
-    if      ( s == YUIWidget_Bottom		)	w = parseAlignment		( p, opt, term, ol, n, YAlignUnchanged,	YAlignEnd	);
+    if	    ( s == YUIWidget_Bottom		)	w = parseAlignment		( p, opt, term, ol, n, YAlignUnchanged,	YAlignEnd	);
+    else if ( s == YUIWidget_BusyIndicator	)	w = parseBusyIndicator		( p, opt, term, ol, n );
     else if ( s == YUIWidget_ButtonBox		)	w = parseButtonBox		( p, opt, term, ol, n );
     else if ( s == YUIWidget_CheckBox		)	w = parseCheckBox		( p, opt, term, ol, n );
     else if ( s == YUIWidget_CheckBoxFrame	)	w = parseCheckBoxFrame		( p, opt, term, ol, n );
@@ -263,7 +265,7 @@ YCPDialogParser::parseWidgetTreeTerm( YWidget *		p,
     else if ( s == YUIWidget_Empty		)	w = parseEmpty			( p, opt, term, ol, n );
     else if ( s == YUIWidget_Frame		)	w = parseFrame			( p, opt, term, ol, n );
     else if ( s == YUIWidget_HBox		)	w = parseLayoutBox		( p, opt, term, ol, n, YD_HORIZ );
-    else if ( s == YUIWidget_HCenter		)	w = parseAlignment		( p, opt, term, ol, n, YAlignCenter, 	YAlignUnchanged );
+    else if ( s == YUIWidget_HCenter		)	w = parseAlignment		( p, opt, term, ol, n, YAlignCenter,	YAlignUnchanged );
     else if ( s == YUIWidget_HSpacing		)	w = parseSpacing		( p, opt, term, ol, n, YD_HORIZ, false );
     else if ( s == YUIWidget_HSquash		)	w = parseSquash			( p, opt, term, ol, n, true,  false );
     else if ( s == YUIWidget_HStretch		)	w = parseSpacing		( p, opt, term, ol, n, YD_HORIZ, true );
@@ -306,26 +308,25 @@ YCPDialogParser::parseWidgetTreeTerm( YWidget *		p,
     else if ( s == YUIWidget_VSquash		)	w = parseSquash			( p, opt, term, ol, n, false, true );
     else if ( s == YUIWidget_VStretch		)	w = parseSpacing		( p, opt, term, ol, n, YD_VERT, true );
     else if ( s == YUIWidget_VWeight		)	w = parseWeight			( p, opt, term, ol, n, YD_VERT );
-    else if ( s == YUIWidget_BusyIndicator	)	w = parseBusyIndicator		( p, opt, term, ol, n );
 
     // Special widgets - may or may not be supported by the specific UI.
     // The YCP application should ask for presence of such a widget with Has???Widget() prior to creating one.
 
-    else if ( s == YUISpecialWidget_DateField		)	w = parseDateField		( p, opt, term, ol, n );
-    else if ( s == YUISpecialWidget_DummySpecialWidget	)	w = parseDummySpecialWidget	( p, opt, term, ol, n );
-    else if ( s == YUISpecialWidget_DownloadProgress	)	w = parseDownloadProgress	( p, opt, term, ol, n );
     else if ( s == YUISpecialWidget_BarGraph		)	w = parseBarGraph		( p, opt, term, ol, n );
+    else if ( s == YUISpecialWidget_DateField		)	w = parseDateField		( p, opt, term, ol, n );
+    else if ( s == YUISpecialWidget_DownloadProgress	)	w = parseDownloadProgress	( p, opt, term, ol, n );
     else if ( s == YUISpecialWidget_DumbTab		)	w = parseDumbTab		( p, opt, term, ol, n );
+    else if ( s == YUISpecialWidget_DummySpecialWidget	)	w = parseDummySpecialWidget	( p, opt, term, ol, n );
+    else if ( s == YUISpecialWidget_Graph		)	w = parseGraph			( p, opt, term, ol, n );
     else if ( s == YUISpecialWidget_HMultiProgressMeter	)	w = parseMultiProgressMeter	( p, opt, term, ol, n, YD_HORIZ );
-    else if ( s == YUISpecialWidget_VMultiProgressMeter	)	w = parseMultiProgressMeter	( p, opt, term, ol, n, YD_VERT  );
     else if ( s == YUISpecialWidget_PartitionSplitter	)	w = parsePartitionSplitter	( p, opt, term, ol, n );
     else if ( s == YUISpecialWidget_PatternSelector	)	w = parsePatternSelector	( p, opt, term, ol, n );
     else if ( s == YUISpecialWidget_SimplePatchSelector	)	w = parseSimplePatchSelector	( p, opt, term, ol, n );
     else if ( s == YUISpecialWidget_Slider		)	w = parseSlider			( p, opt, term, ol, n );
     else if ( s == YUISpecialWidget_TimeField		)	w = parseTimeField		( p, opt, term, ol, n );
-    else if ( s == YUISpecialWidget_Wizard		)	w = parseWizard			( p, opt, term, ol, n );
     else if ( s == YUISpecialWidget_TimezoneSelector	)	w = parseTimezoneSelector	( p, opt, term, ol, n );
-    else if ( s == YUISpecialWidget_Graph		)	w = parseGraph			( p, opt, term, ol, n );
+    else if ( s == YUISpecialWidget_VMultiProgressMeter	)	w = parseMultiProgressMeter	( p, opt, term, ol, n, YD_VERT	);
+    else if ( s == YUISpecialWidget_Wizard		)	w = parseWizard			( p, opt, term, ol, n );
     else
     {
 	YUI_THROW( YUIException( string( "Unknown widget type " ) + s.c_str() ) );
@@ -355,14 +356,14 @@ YCPDialogParser::parseWidgetTreeTerm( YWidget *		p,
 	     */
 	}
 
-	if ( opt.isDisabled.value() 	)	w->setDisabled();
-	if ( opt.notifyMode.value() 	)	w->setNotify( true );
-	if ( opt.notifyContextMenu.value())	w->setNotifyContextMenu( true );
-	if ( opt.keyEvents.value()	)	w->setSendKeyEvents( true );
-	if ( opt.autoShortcut.value()	)	w->setAutoShortcut( true );
-	if ( opt.isHStretchable.value()	)	w->setStretchable( YD_HORIZ, true );
-	if ( opt.isVStretchable.value()	)	w->setStretchable( YD_VERT,  true );
-	if ( opt.key_Fxx.value() > 0	)
+	if ( opt.isDisabled.value()		)	w->setDisabled();
+	if ( opt.notifyMode.value()		)	w->setNotify( true );
+	if ( opt.notifyContextMenu.value()	)	w->setNotifyContextMenu( true );
+	if ( opt.keyEvents.value()		)	w->setSendKeyEvents( true );
+	if ( opt.autoShortcut.value()		)	w->setAutoShortcut( true );
+	if ( opt.isHStretchable.value()		)	w->setStretchable( YD_HORIZ, true );
+	if ( opt.isVStretchable.value()		)	w->setStretchable( YD_VERT,  true );
+	if ( opt.key_Fxx.value() > 0		)
 	{
 	    YPushButton * button = dynamic_cast<YPushButton *> (w);
 	    YButtonRole oldRole = button ? button->role() : YCustomButton;
@@ -371,7 +372,7 @@ YCPDialogParser::parseWidgetTreeTerm( YWidget *		p,
 	    if ( button && oldRole != button->role() && opt.customButton.value() )
 	    {
 		// Application requested button role override
-		
+
 		yuiMilestone() << "Overriding button role for " << button
 			       << " to YCustomButton" << endl;
 		button->setRole( YCustomButton );
@@ -476,7 +477,7 @@ YCPDialogParser::parseEmpty( YWidget * parent, YWidgetOpt & opt,
 
 /**
  * @widget	HSpacing VSpacing HStretch VStretch
- * @id          Spacing
+ * @id		Spacing
  * @short	Fixed size empty space for layout
  * @class	YSpacing
  * @optarg	integer|float size
@@ -485,7 +486,7 @@ YCPDialogParser::parseEmpty( YWidget * parent, YWidgetOpt & opt,
  * @example	HStretch1.rb
  * @example	Layout-Buttons-Equal-Even-Spaced1.rb
  * @example	Table2.rb
- * @example     Table3.rb
+ * @example	Table3.rb
  *
  *
  *
@@ -501,9 +502,9 @@ YCPDialogParser::parseEmpty( YWidget * parent, YWidgetOpt & opt,
  *
  * If <tt>size</tt> is omitted, it defaults to 1.
  * <tt>HSpacing()</tt> will create a horizontal spacing with default width and zero height.
- * <tt>VSpacing()</tt> will create a vertical   spacing with default height and zero width.
+ * <tt>VSpacing()</tt> will create a vertical	spacing with default height and zero width.
  * <tt>HStretch()</tt> will create a horizontal stretch with zero width and height.
- * <tt>VStretch()</tt> will create a vertical   stretch with zero width and height.
+ * <tt>VStretch()</tt> will create a vertical	stretch with zero width and height.
  *
  * A HStretch or VStretch with a size specification will take at least the
  * specified amount of space, but it will take more (in that dimension) if
@@ -550,15 +551,15 @@ YCPDialogParser::parseSpacing( YWidget * parent, YWidgetOpt & opt,
 
 /**
  * @widget	Left Right Top Bottom HCenter VCenter HVCenter
- * @id          Alignment
+ * @id		Alignment
  * @short	Layout alignment
  * @class	YAlignment
  * @optarg	BackgroundPixmap( "dir/pixmap.png" )	background pixmap
  * @arg		term child The contained child widget
  * @example	HCenter1.rb
- * @example     HCenter2.rb
- * @example     HCenter3.rb
- * @example     Alignment1.rb
+ * @example	HCenter2.rb
+ * @example	HCenter3.rb
+ * @example	Alignment1.rb
  *
  *
  *
@@ -621,8 +622,8 @@ YCPDialogParser::parseAlignment( YWidget * parent, YWidgetOpt & opt,
 
     if ( YUI::app()->reverseLayout() )
     {
-	if 	( horAlign == YAlignBegin )	horAlign = YAlignEnd;
-	else if ( horAlign == YAlignEnd   )	horAlign = YAlignBegin;
+	if	( horAlign == YAlignBegin )	horAlign = YAlignEnd;
+	else if ( horAlign == YAlignEnd	  )	horAlign = YAlignBegin;
     }
 
     rejectAllOptions( term, optList );
@@ -640,15 +641,15 @@ YCPDialogParser::parseAlignment( YWidget * parent, YWidgetOpt & opt,
 
 /**
  * @widget	MinWidth MinHeight MinSize
- * @id          MinSize
+ * @id		MinSize
  * @short	Layout minimum size
  * @class	YAlignment
  * @arg		float|integer size minimum width (for MinWidth or MinSize) or minimum heigh (for MinHeight)
  * @optarg	float|integer height (only for MinSize)
  * @arg		term child The contained child widget
  * @example	MinWidth1.rb
- * @example     MinHeight1.rb
- * @example     MinSize1.rb
+ * @example	MinHeight1.rb
+ * @example	MinSize1.rb
  *
  *
  *
@@ -676,7 +677,7 @@ YCPDialogParser::parseMinSize( YWidget * parent, YWidgetOpt & opt,
 	    THROW_BAD_ARGS( term );
 	}
 
-	minWidth  = toFloat( term->value( argnr   ) );
+	minWidth  = toFloat( term->value( argnr	  ) );
 	minHeight = toFloat( term->value( argnr+1 ) );
 	childTerm = term->value( argnr+2 )->asTerm();
     }
@@ -708,14 +709,14 @@ YCPDialogParser::parseMinSize( YWidget * parent, YWidgetOpt & opt,
 
 /**
  * @widget	MarginBox
- * @id          MarginBox
+ * @id		MarginBox
  * @short	Margins around one child widget
  * @class	YAlignment
  * @arg		float horMargin	 margin left and right of the child widget
  * @arg		float vertMargin margin above and below the child widget
  * @arg		term child The contained child widget
  * @example	MarginBox1.rb
- * @example     MarginBox2.rb
+ * @example	MarginBox2.rb
  *
  *
  *
@@ -733,12 +734,12 @@ YWidget *
 YCPDialogParser::parseMarginBox( YWidget * parent, YWidgetOpt & opt,
 				 const YCPTerm & term, const YCPList & optList, int argnr )
 {
-    float 	leftMargin	= 0.0;
-    float 	rightMargin	= 0.0;
-    float 	topMargin 	= 0.0;
+    float	leftMargin	= 0.0;
+    float	rightMargin	= 0.0;
+    float	topMargin	= 0.0;
     float	bottomMargin	= 0.0;
 
-    bool 	paramOK		= false;
+    bool	paramOK		= false;
     int		argc		= term->size() - argnr;
     YCPTerm	childTerm	= YCPNull();
 
@@ -748,15 +749,15 @@ YCPDialogParser::parseMarginBox( YWidget * parent, YWidgetOpt & opt,
 	 isNum( term->value( argnr+1 ) ) &&
 	 term->value( argnr+2 )->isTerm() )
     {
-	leftMargin = rightMargin  = toFloat( term->value( argnr   ) );
+	leftMargin = rightMargin  = toFloat( term->value( argnr	  ) );
 	topMargin  = bottomMargin = toFloat( term->value( argnr+1 ) );
 	childTerm  = term->value( argnr+2 )->asTerm();
-	paramOK    = true;
+	paramOK	   = true;
     }
 
     if ( ! paramOK && argc == 5 ) // MarginBox(leftMargin(99), rightMargin(99), topMargin(99), bottomMargin(99), child );
     {
- 	paramOK = term->value( argnr+4)->isTerm();
+	paramOK = term->value( argnr+4)->isTerm();
 
 	for ( int i=argnr; i < argnr+4 && paramOK; i++ )
 	{
@@ -767,9 +768,9 @@ YCPDialogParser::parseMarginBox( YWidget * parent, YWidgetOpt & opt,
 		if ( marginTerm->size() == 1 && isNum( marginTerm->value(0) ) )
 		{
 		    float margin = toFloat( marginTerm->value(0) );
-		    if      ( marginTerm->name() == YUISymbol_leftMargin   )	leftMargin   = margin;
+		    if	    ( marginTerm->name() == YUISymbol_leftMargin   )	leftMargin   = margin;
 		    else if ( marginTerm->name() == YUISymbol_rightMargin  )	rightMargin  = margin;
-		    else if ( marginTerm->name() == YUISymbol_topMargin    )	topMargin    = margin;
+		    else if ( marginTerm->name() == YUISymbol_topMargin	   )	topMargin    = margin;
 		    else if ( marginTerm->name() == YUISymbol_bottomMargin )	bottomMargin = margin;
 		    else							paramOK = false;
 		}
@@ -809,7 +810,7 @@ YCPDialogParser::parseMarginBox( YWidget * parent, YWidgetOpt & opt,
  * @arg		term child the contained child widget
  * @example	Frame1.rb
  * @example	Frame2.rb
- * @example     InputField5.rb
+ * @example	InputField5.rb
  *
  *
  *
@@ -845,7 +846,7 @@ YCPDialogParser::parseFrame( YWidget * parent, YWidgetOpt & opt,
 
 /**
  * @widget	HSquash VSquash HVSquash
- * @id          Squash
+ * @id		Squash
  * @short	Layout aid: Minimize widget to its preferred size
  * @class	YSquash
  * @arg		term child the child widget
@@ -890,14 +891,14 @@ YCPDialogParser::parseSquash( YWidget * parent, YWidgetOpt & opt,
 
 /**
  * @widget	HWeight VWeight
- * @id          Weight
+ * @id		Weight
  * @short	Control relative size of layouts
  * @class	YWeight
  * @arg		integer weight the new weight of the child widget
  * @arg		term child the child widget
  * @example	Weight1.rb
  * @example	Layout-Buttons-Equal-Even-Spaced1.rb
- * @example     Layout-Buttons-Equal-Even-Spaced2.rb
+ * @example	Layout-Buttons-Equal-Even-Spaced2.rb
  * @example	Layout-Buttons-Equal-Growing.rb
  * @example	Layout-Mixed.rb
  * @example	Layout-Weights1.rb
@@ -925,8 +926,8 @@ YCPDialogParser::parseWeight( YWidget * parent, YWidgetOpt & opt,
 			      YUIDimension dim )
 {
     if ( term->size() != argnr + 2
-	 || !term->value(argnr)->isInteger()
-	 || !term->value(argnr+1)->isTerm())
+	 || ! term->value(argnr)->isInteger()
+	 || ! term->value( argnr+1 )->isTerm())
     {
 	THROW_BAD_ARGS( term );
     }
@@ -951,7 +952,7 @@ YCPDialogParser::parseWeight( YWidget * parent, YWidgetOpt & opt,
 
 /**
  * @widget	HBox VBox
- * @id          Box
+ * @id		Box
  * @short	Generic layout: Arrange widgets horizontally or vertically
  * @class	LayoutBox
  * @optarg	term child1 the first child widget
@@ -962,9 +963,9 @@ YCPDialogParser::parseWeight( YWidget * parent, YWidgetOpt & opt,
  *
  * @example	VBox1.rb
  * @example	HBox1.rb
- * @example     Layout-Buttons-Equal-Growing.rb
- * @example     Layout-Fixed.rb
- * @example     Layout-Mixed.rb
+ * @example	Layout-Buttons-Equal-Growing.rb
+ * @example	Layout-Fixed.rb
+ * @example	Layout-Mixed.rb
  *
  *
  *
@@ -1009,7 +1010,7 @@ YCPDialogParser::parseLayoutBox( YWidget * parent, YWidgetOpt & opt,
 
 /**
  * @widget	ButtonBox
- * @id          ButtonBox
+ * @id		ButtonBox
  * @short	Layout for push buttons that takes button order into account
  * @class	ButtonBox
  * @arg		term button1 the first button
@@ -1085,7 +1086,7 @@ YCPDialogParser::parseLayoutBox( YWidget * parent, YWidgetOpt & opt,
  * ButtonBox widgets are horizontally stretchable and vertically
  * non-stretchable. If there is more space, their layout policy (depending on
  * KDE or GNOME button order) specifies whether to center or right-align the
- * buttons. 
+ * buttons.
  **/
 
 YWidget *
@@ -1108,7 +1109,7 @@ YCPDialogParser::parseButtonBox( YWidget * parent, YWidgetOpt & opt,
     for ( int buttonNo=argnr; buttonNo < term->size(); buttonNo++ )
     {
 	YWidgetOpt opt;
-	YWidget     * child  = parseWidgetTreeTerm( buttonBox, opt, term->value( buttonNo )->asTerm() );
+	YWidget	    * child  = parseWidgetTreeTerm( buttonBox, opt, term->value( buttonNo )->asTerm() );
 	YPushButton * button = dynamic_cast<YPushButton *> (child);
 	YUI_CHECK_PTR( button );
 
@@ -1125,15 +1126,15 @@ YCPDialogParser::parseButtonBox( YWidget * parent, YWidgetOpt & opt,
 
 	    YButtonRole role = YCustomButton;
 
-	    if 		( startsWith( id, "ok"  	) )	role = YOKButton;
-	    else if 	( startsWith( id, "yes" 	) )	role = YOKButton;
-	    else if 	( startsWith( id, "continue" 	) )	role = YOKButton;
-	    else if 	( startsWith( id, "accept" 	) )	role = YOKButton;
-	    
-	    else if 	( startsWith( id, "cancel" 	) )	role = YCancelButton;
-	    else if 	( startsWith( id, "no" 		) )	role = YCancelButton;
-	    else if 	( startsWith( id, "apply" 	) )	role = YApplyButton;
-	    else if 	( startsWith( id, "help" 	) )	role = YHelpButton;
+	    if		( startsWith( id, "ok"		) )	role = YOKButton;
+	    else if	( startsWith( id, "yes"		) )	role = YOKButton;
+	    else if	( startsWith( id, "continue"	) )	role = YOKButton;
+	    else if	( startsWith( id, "accept"	) )	role = YOKButton;
+
+	    else if	( startsWith( id, "cancel"	) )	role = YCancelButton;
+	    else if	( startsWith( id, "no"		) )	role = YCancelButton;
+	    else if	( startsWith( id, "apply"	) )	role = YApplyButton;
+	    else if	( startsWith( id, "help"	) )	role = YHelpButton;
 
 	    if ( role != YCustomButton )
 	    {
@@ -1208,7 +1209,7 @@ YCPDialogParser::parseLabel( YWidget * parent, YWidgetOpt & opt,
 			     bool isHeading )
 {
     if ( term->size() - argnr != 1
-	 || !term->value(argnr)->isString())
+	 || ! term->value(argnr)->isString())
     {
 	THROW_BAD_ARGS( term );
     }
@@ -1267,15 +1268,15 @@ YCPDialogParser::parseRichText( YWidget * parent, YWidgetOpt & opt,
 				const YCPTerm & term, const YCPList & optList, int argnr )
 {
     if ( term->size() - argnr != 1
-	 || !term->value(argnr)->isString())
+	 || ! term->value(argnr)->isString())
     {
 	THROW_BAD_ARGS( term );
     }
 
-    string 	text 		= term->value( argnr )->asString()->value();
-    bool 	plainTextMode	= false;
-    bool 	autoScrollDown	= false;
-    bool 	shrinkable	= false;
+    string	text		= term->value( argnr )->asString()->value();
+    bool	plainTextMode	= false;
+    bool	autoScrollDown	= false;
+    bool	shrinkable	= false;
 
     for ( int o=0; o < optList->size(); o++ )
     {
@@ -1283,8 +1284,8 @@ YCPDialogParser::parseRichText( YWidget * parent, YWidgetOpt & opt,
 	{
 	    string sym = optList->value(o)->asSymbol()->symbol();
 
-	    if	    ( sym  == YUIOpt_plainText	    ) 	plainTextMode  = true;
-	    else if ( sym  == YUIOpt_autoScrollDown ) 	autoScrollDown = true;
+	    if	    ( sym  == YUIOpt_plainText	    )	plainTextMode  = true;
+	    else if ( sym  == YUIOpt_autoScrollDown )	autoScrollDown = true;
 	    else if ( sym  == YUIOpt_shrinkable	    )	shrinkable     = true;
 	    else    logUnknownOption( term, optList->value(o) );
 	}
@@ -1346,8 +1347,8 @@ YCPDialogParser::parseLogView( YWidget * parent, YWidgetOpt & opt,
     rejectAllOptions( term,optList );
 
     string	label		= term->value( argnr   )->asString()->value();
-    int 	visibleLines	= term->value( argnr+1 )->asInteger()->value();
-    int 	maxLines	= term->value( argnr+2 )->asInteger()->value();
+    int		visibleLines	= term->value( argnr+1 )->asInteger()->value();
+    int		maxLines	= term->value( argnr+2 )->asInteger()->value();
 
     return YUI::widgetFactory()->createLogView( parent, label, visibleLines, maxLines );
 }
@@ -1411,16 +1412,16 @@ YCPDialogParser::parsePushButton( YWidget * parent, YWidgetOpt & opt,
 				  const YCPTerm & term, const YCPList & optList, int argnr,
 				  bool isIconButton )
 {
-    string 	label;
-    string 	iconName;
-    bool   	isDefaultButton = false;
-    YButtonRole	role            = YCustomButton;
+    string	label;
+    string	iconName;
+    bool	isDefaultButton = false;
+    YButtonRole	role		= YCustomButton;
 
     if ( isIconButton )
     {
 	if ( term->size() - argnr != 2
 	     || ! term->value(argnr)->isString()
-	     || ! term->value(argnr+1)->isString() )
+	     || ! term->value( argnr+1 )->isString() )
 	{
 	    THROW_BAD_ARGS( term );
 	}
@@ -1431,7 +1432,7 @@ YCPDialogParser::parsePushButton( YWidget * parent, YWidgetOpt & opt,
     else
     {
 	if ( term->size() - argnr != 1
-	     || !term->value(argnr)->isString() )
+	     || ! term->value(argnr)->isString() )
 	{
 	    THROW_BAD_ARGS( term );
 	}
@@ -1447,12 +1448,12 @@ YCPDialogParser::parsePushButton( YWidget * parent, YWidgetOpt & opt,
 	{
 	    string sym = optList->value(o)->asSymbol()->symbol();
 
-	    if	    ( sym == YUIOpt_default    	)	isDefaultButton = true;
+	    if	    ( sym == YUIOpt_default	)	isDefaultButton = true;
 	    else if ( sym == YUIOpt_okButton	)	role = YOKButton;
 	    else if ( sym == YUIOpt_cancelButton)	role = YCancelButton;
 	    else if ( sym == YUIOpt_applyButton)	role = YApplyButton;
-	    else if ( sym == YUIOpt_helpButton 	)	role = YHelpButton;
-            else if ( sym == YUIOpt_relNotesButton )    role = YRelNotesButton;
+	    else if ( sym == YUIOpt_helpButton	)	role = YHelpButton;
+	    else if ( sym == YUIOpt_relNotesButton )	role = YRelNotesButton;
 	    else if ( sym == YUIOpt_customButton)	opt.customButton.setValue( true );
 	    else logUnknownOption( term, optList->value(o) );
 	}
@@ -1570,8 +1571,8 @@ YCPDialogParser::parseCheckBox( YWidget * parent, YWidgetOpt & opt,
 {
     int size = term->size() - argnr;
     if ( size < 1 || size > 2
-	 || !term->value( argnr )->isString()
-	 || ( size == 2 && ! term->value(argnr+1)->isBoolean() ) )
+	 || ! term->value( argnr )->isString()
+	 || ( size == 2 && ! term->value( argnr+1 )->isBoolean() ) )
     {
 	THROW_BAD_ARGS( term );
     }
@@ -1640,8 +1641,8 @@ YCPDialogParser::parseCheckBoxFrame( YWidget * parent, YWidgetOpt & opt,
 	THROW_BAD_ARGS( term );
     }
 
-    string	label		 = term->value( argnr   )->asString()->value();
-    bool	checked 	 = term->value( argnr+1 )->asBoolean()->value();
+    string	label		 = term->value( argnr	)->asString()->value();
+    bool	checked		 = term->value( argnr+1 )->asBoolean()->value();
     YCPTerm	childTerm	 = term->value( argnr+2 )->asTerm();
     bool	autoEnable	 = true;
     bool	invertAutoEnable = false;
@@ -1755,7 +1756,7 @@ YCPDialogParser::parseRadioButtonGroup( YWidget * parent, YWidgetOpt & opt,
 					const YCPTerm & term, const YCPList & optList, int argnr )
 {
     if ( term->size() != argnr+1
-	 || !term->value(argnr)->isTerm())
+	 || ! term->value(argnr)->isTerm())
     {
 	THROW_BAD_ARGS( term );
     }
@@ -1786,14 +1787,14 @@ YCPDialogParser::parseRadioButtonGroup( YWidget * parent, YWidgetOpt & opt,
  * @example	InputField6.rb
  * @example	Password1.rb
  * @example	Password2.rb
- * @example     InputField-setInputMaxLength.rb
+ * @example	InputField-setInputMaxLength.rb
  *
  *
  *
  * This widget is a one line text entry field with a label above it. An initial
  * text can be provided.
  *
- * @note        You can and should set a keyboard shortcut within the
+ * @note	You can and should set a keyboard shortcut within the
  * label. When the user presses the hotkey, the corresponding text entry widget
  * will get the keyboard focus.
  *
@@ -1812,11 +1813,9 @@ YCPDialogParser::parseInputField( YWidget * parent, YWidgetOpt & opt,
 				 const YCPTerm & term, const YCPList & optList, int argnr,
 				 bool passwordMode, bool bugCompatibilityMode )
 {
-    static bool postedBugCompatibilityWarning = false;
-
     if ( term->size() - argnr < 1 || term->size() - argnr > 2
-	 || !term->value(argnr)->isString()
-	 || (term->size() == argnr+2 && !term->value(argnr+1)->isString()))
+	 || ! term->value(argnr)->isString()
+	 || (term->size() == argnr+2 && ! term->value( argnr+1 )->isString()))
     {
 	THROW_BAD_ARGS( term );
     }
@@ -1845,23 +1844,6 @@ YCPDialogParser::parseInputField( YWidget * parent, YWidgetOpt & opt,
     else if ( bugCompatibilityMode )
     {
 	inputField->setStretchable( YD_HORIZ, true );
-
-	if ( ! postedBugCompatibilityWarning )
-	{
-	    yuiWarning() <<
-		"\n"
-		"\nUsing `TextEntry() in bug compatibiltiy mode."
-		"\nThis is equivalent to `InputField(`opt(`hstretch), ...)."
-		"\nThis makes the field grab as much space horizontally as it can get,"
-		"\ntypically making it stretch across the entire width of the dialog."
-		"\nWithout this hstretch, the field will take a reasonable default width."
-		"\n"
-		"\nIf this `hstretch is really desired, please use `InputField(`opt(`hstretch), ...)."
-		"\nIf it is not, please use `InputField() without `hstretch."
-		"\n\n" << endl;
-
-	    postedBugCompatibilityWarning = true;
-	}
     }
 
 
@@ -1898,8 +1880,8 @@ YCPDialogParser::parseMultiLineEdit( YWidget * parent, YWidgetOpt & opt,
 {
 
     if ( term->size() - argnr < 1 || term->size() - argnr > 2
-	 || !term->value(argnr)->isString()
-	 || (term->size() == argnr+2 && !term->value(argnr+1)->isString()))
+	 || ! term->value(argnr)->isString()
+	 || ( term->size() == argnr+2 && ! term->value( argnr+1 )->isString() ) )
     {
 	THROW_BAD_ARGS( term );
     }
@@ -2086,7 +2068,7 @@ YCPDialogParser::parseMultiSelectionBox( YWidget * parent, YWidgetOpt & opt,
  * parameter indicating the selected state. Only one of the items may have this
  * parameter set to "true"; this will be the default selection on startup.
  *
- * @note         You can and should set a keyboard shortcut within the
+ * @note	 You can and should set a keyboard shortcut within the
  * label. When the user presses the hotkey, the combo box will get the keyboard
  * focus.
  *
@@ -2098,7 +2080,7 @@ YCPDialogParser::parseComboBox( YWidget * parent, YWidgetOpt & opt,
 {
     int numargs = term->size() - argnr;
     if ( numargs < 1 || numargs > 2
-	 || !term->value(argnr)->isString()
+	 || ! term->value(argnr)->isString()
 	 || ( numargs >= 2 && ! term->value( argnr+1 )->isList() ) )
     {
 	THROW_BAD_ARGS( term );
@@ -2132,7 +2114,7 @@ YCPDialogParser::parseComboBox( YWidget * parent, YWidgetOpt & opt,
  * @class	YTree
  * @arg		string		label
  * @optarg	itemList	items	the items contained in the tree
- *              <code>
+ *		<code>
  *		itemList ::=
  *			[
  *				item
@@ -2148,7 +2130,7 @@ YCPDialogParser::parseComboBox( YWidget * parent, YWidgetOpt & opt,
  *				[ , true | false ]
  *				[ , itemList ]
  *			)
- *              </code>
+ *		</code>
  *
  *		The boolean parameter inside Item() indicates whether or not
  *		the respective tree item should be opened by default - if it
@@ -2156,7 +2138,7 @@ YCPDialogParser::parseComboBox( YWidget * parent, YWidgetOpt & opt,
  *		and opening subtrees. If the UI cannot handle this, all
  *		subtrees will always be open.
  *
- * @option	multiSelection	user can select multiple items at once 
+ * @option	multiSelection	user can select multiple items at once
  * @option	immediate	make :notify trigger immediately when the selected item changes
  * @example	Tree1.rb
  * @example	Tree2.rb
@@ -2202,9 +2184,9 @@ YCPDialogParser::parseTree( YWidget * parent, YWidgetOpt & opt,
 
     for ( int o=0; o < optList->size(); o++ )
     {
-	if ( optList->value(o)->isSymbol() && optList->value(o)->asSymbol()->symbol() == YUIOpt_immediate )	          immediate  = true;
-        else if ( optList->value(o)->isSymbol() && optList->value(o)->asSymbol()->symbol() == YUIOpt_multiSelection )     multiSelection = true;
-        else if ( optList->value(o)->isSymbol() && optList->value(o)->asSymbol()->symbol() == YUIOpt_recursiveSelection ) recursiveSelection = true;
+	if ( optList->value(o)->isSymbol() && optList->value(o)->asSymbol()->symbol() == YUIOpt_immediate )		  immediate  = true;
+	else if ( optList->value(o)->isSymbol() && optList->value(o)->asSymbol()->symbol() == YUIOpt_multiSelection )	  multiSelection = true;
+	else if ( optList->value(o)->isSymbol() && optList->value(o)->asSymbol()->symbol() == YUIOpt_recursiveSelection ) recursiveSelection = true;
 	else logUnknownOption( term, optList->value(o) );
     }
 
@@ -2223,7 +2205,7 @@ YCPDialogParser::parseTree( YWidget * parent, YWidgetOpt & opt,
 
     if ( immediate )
 	tree->setImmediateMode( true ); // includes setNotify()
-    
+
     return tree;
 }
 
@@ -2287,13 +2269,13 @@ YCPDialogParser::parseTree( YWidget * parent, YWidgetOpt & opt,
  *
  * @code
  * Table(Id(:players),
- *        Header("Nick", "Age", "Role"),
- *        [
- *         Item(Id("Bluebird"), "Bluebird,	18, 	"Scout"  ),
- *         Item(Id("Ozzz"    ), "Ozzz",	23, 	"Wizard" ),
- *         Item(Id("Wannabe" ), "Wannabe",	17 ),
- *         Item(Id("Coxxan"  ), "Coxxan",	26, 	"Warrior")
- *        ]
+ *	  Header("Nick", "Age", "Role"),
+ *	  [
+ *	   Item(Id("Bluebird"), "Bluebird,	18,	"Scout"	 ),
+ *	   Item(Id("Ozzz"    ), "Ozzz",	23,	"Wizard" ),
+ *	   Item(Id("Wannabe" ), "Wannabe",	17 ),
+ *	   Item(Id("Coxxan"  ), "Coxxan",	26,	"Warrior")
+ *	  ]
  * )
  * @endcode
  *
@@ -2306,13 +2288,13 @@ YCPDialogParser::parseTree( YWidget * parent, YWidgetOpt & opt,
  *
  * @code
  * Table(Id(:players),
- *        Header("Nick", "Age", "Role"),
- *        [
- *         Item(Id("Bluebird"), "Bluebird, 18, cell(Icon("scout.png"),    "Scout" )  ),
- *         Item(Id("Ozzz"    ), "Ozzz",    23,                              "Wizard"   ),
- *         Item(Id("Wannabe" ), "Wannabe", cell(Icon("underage.png", 17 )            ),
- *         Item(Id("Coxxan"  ), "Coxxan",  cell(Icon("oldman.png",   26 ), "Warrior" )
- *        ]
+ *	  Header("Nick", "Age", "Role"),
+ *	  [
+ *	   Item(Id("Bluebird"), "Bluebird, 18, cell(Icon("scout.png"),	  "Scout" )  ),
+ *	   Item(Id("Ozzz"    ), "Ozzz",	   23,				    "Wizard"   ),
+ *	   Item(Id("Wannabe" ), "Wannabe", cell(Icon("underage.png", 17 )	     ),
+ *	   Item(Id("Coxxan"  ), "Coxxan",  cell(Icon("oldman.png",   26 ), "Warrior" )
+ *	  ]
  * )
  * @endcode
  *
@@ -2326,9 +2308,9 @@ YCPDialogParser::parseTable( YWidget * parent, YWidgetOpt & opt,
 {
     int numArgs = term->size() - argnr;
     if ( numArgs < 1 || numArgs > 2
-	 || !term->value(argnr)->isTerm()
+	 || ! term->value(argnr)->isTerm()
 	 || term->value(argnr)->asTerm()->name() != YUISymbol_header
-	 || (numArgs == 2 && !term->value(argnr+1)->isList()))
+	 || (numArgs == 2 && ! term->value( argnr+1 )->isList()))
     {
 	THROW_BAD_ARGS( term );
     }
@@ -2390,8 +2372,8 @@ YCPDialogParser::parseTableHeader( const YCPTerm & headerTerm )
 	    YAlignmentType	alignment	= YAlignBegin;
 	    YCPTerm		colHeaderTerm	= colHeader->asTerm();
 
-	    if      ( colHeaderTerm->name() == YUISymbol_Left   ) alignment = YAlignBegin;
-	    else if ( colHeaderTerm->name() == YUISymbol_Right  ) alignment = YAlignEnd;
+	    if	    ( colHeaderTerm->name() == YUISymbol_Left	) alignment = YAlignBegin;
+	    else if ( colHeaderTerm->name() == YUISymbol_Right	) alignment = YAlignEnd;
 	    else if ( colHeaderTerm->name() == YUISymbol_Center ) alignment = YAlignCenter;
 	    else
 	    {
@@ -2462,17 +2444,17 @@ YCPDialogParser::parseProgressBar( YWidget * parent, YWidgetOpt & opt,
     int s = term->size() - argnr;
     if ( s < 1
 	 || s > 3
-	 || (s >= 1 && !term->value(argnr)->isString())
-	 || (s >= 2 && !term->value(argnr+1)->isInteger())
-	 || (s >= 3 && !term->value(argnr+2)->isInteger()))
+	 || (s >= 1 && ! term->value(argnr)->isString())
+	 || (s >= 2 && ! term->value( argnr+1 )->isInteger())
+	 || (s >= 3 && ! term->value( argnr+2 )->isInteger()))
     {
 	THROW_BAD_ARGS( term );
     }
 
     rejectAllOptions( term,optList );
 
-    string  label        = term->value( argnr )->asString()->value();
-    int	    maxValue     = 100;
+    string  label	 = term->value( argnr )->asString()->value();
+    int	    maxValue	 = 100;
     int	    initialValue = 0;
 
     if ( s >= 2 ) maxValue	= term->value( argnr+1 )->asInteger()->value();
@@ -2496,7 +2478,7 @@ YCPDialogParser::parseProgressBar( YWidget * parent, YWidgetOpt & opt,
  * @option	animated	show an animated image (MNG, animated GIF)
  * @option	scaleToFit	scale the pixmap so it fits the available space: zoom in or out as needed
  * @option	zeroWidth	make widget report a preferred width of 0
- * @option	zeroHeight 	make widget report a preferred height of 0
+ * @option	zeroHeight	make widget report a preferred height of 0
  * @example	Image1.rb
  * @example	Image-animated.rb
  * @example	Image-scaled.rb
@@ -2508,7 +2490,7 @@ YCPDialogParser::parseProgressBar( YWidget * parent, YWidgetOpt & opt,
  * Use <tt>Opt( :zeroWidth )</tt> and / or <tt>Opt( :zeroHeight )</tt>
  * if the real size of the image widget is determined by outside factors, e.g. by the size
  * of neighboring widgets. With those options you can override the preferred size of
- * the image widget and make it show just a part of the image.  If more screen space is
+ * the image widget and make it show just a part of the image.	If more screen space is
  * available, more of the image is shown, if not, the layout engine doesn't complain about
  * the image widget not getting its preferred size.
  *
@@ -2541,10 +2523,10 @@ YCPDialogParser::parseImage( YWidget * parent, YWidgetOpt & opt,
     }
 
     string	imageFileName	= term->value( argnr )->asString()->value();
-    bool 	zeroWidth 	= false;
-    bool 	zeroHeight 	= false;
-    bool 	animated 	= false;
-    bool 	autoScale	= false;
+    bool	zeroWidth	= false;
+    bool	zeroHeight	= false;
+    bool	animated	= false;
+    bool	autoScale	= false;
 
     for ( int o=0; o < optList->size(); o++ )
     {
@@ -2579,7 +2561,7 @@ YCPDialogParser::parseImage( YWidget * parent, YWidgetOpt & opt,
  *
  * <code> IntField(label, minValue, maxValue, initialValue) </code>
  *
- * @arg		\c string \b label         Explanatory label above the input field
+ * @arg		\c string \b label	   Explanatory label above the input field
  * @arg		\c integer \b minValue	   minimum value
  * @arg		\c integer \b maxValue	   maximum value
  * @arg		\c integer \b initialValue initial value
@@ -2612,10 +2594,10 @@ YCPDialogParser::parseIntField( YWidget * parent, YWidgetOpt & opt,
     int numArgs = term->size() - argnr;
 
     if ( numArgs != 4
-	 || ! term->value(argnr  )->isString()
-	 || ! term->value(argnr+1)->isInteger()
-	 || ! term->value(argnr+2)->isInteger()
-	 || ! term->value(argnr+3)->isInteger()
+	 || ! term->value( argnr   )->isString()
+	 || ! term->value( argnr+1 )->isInteger()
+	 || ! term->value( argnr+2 )->isInteger()
+	 || ! term->value( argnr+3 )->isInteger()
 	 )
     {
 	THROW_BAD_ARGS( term );
@@ -2624,9 +2606,9 @@ YCPDialogParser::parseIntField( YWidget * parent, YWidgetOpt & opt,
     rejectAllOptions( term,optList );
 
     string	label		= term->value( argnr   )->asString()->value();
-    int 	minValue	= term->value( argnr+1 )->asInteger()->value();
-    int 	maxValue	= term->value( argnr+2 )->asInteger()->value();
-    int 	initialValue	= term->value( argnr+3 )->asInteger()->value();
+    int		minValue	= term->value( argnr+1 )->asInteger()->value();
+    int		maxValue	= term->value( argnr+2 )->asInteger()->value();
+    int		initialValue	= term->value( argnr+3 )->asInteger()->value();
 
     return YUI::widgetFactory()->createIntField( parent, label, minValue, maxValue, initialValue );
 }
@@ -2689,13 +2671,13 @@ YCPDialogParser::parsePackageSelector( YWidget * parent, YWidgetOpt & opt,
 	{
 	    string sym = optList->value(o)->asSymbol()->symbol();
 
-	    if	    ( sym == YUIOpt_youMode     	) 	modeFlags |= YPkg_OnlineUpdateMode;
-	    else if ( sym == YUIOpt_updateMode  	) 	modeFlags |= YPkg_UpdateMode;
-	    else if ( sym == YUIOpt_searchMode  	) 	modeFlags |= YPkg_SearchMode;
-	    else if ( sym == YUIOpt_summaryMode 	)	modeFlags |= YPkg_SummaryMode;
+	    if	    ( sym == YUIOpt_youMode		)	modeFlags |= YPkg_OnlineUpdateMode;
+	    else if ( sym == YUIOpt_updateMode		)	modeFlags |= YPkg_UpdateMode;
+	    else if ( sym == YUIOpt_searchMode		)	modeFlags |= YPkg_SearchMode;
+	    else if ( sym == YUIOpt_summaryMode		)	modeFlags |= YPkg_SummaryMode;
 	    else if ( sym == YUIOpt_repoMode		)	modeFlags |= YPkg_RepoMode;
-	    else if ( sym == YUIOpt_testMode 		)	modeFlags |= YPkg_TestMode;
-	    else if ( sym == YUIOpt_repoMgr 		)	modeFlags |= YPkg_RepoMgr;
+	    else if ( sym == YUIOpt_testMode		)	modeFlags |= YPkg_TestMode;
+	    else if ( sym == YUIOpt_repoMgr		)	modeFlags |= YPkg_RepoMgr;
 	    else if ( sym == YUIOpt_confirmUnsupported	)	modeFlags |= YPkg_ConfirmUnsupported;
 	    else logUnknownOption( term, optList->value(o) );
 	}
@@ -2781,7 +2763,7 @@ YCPDialogParser::parseDummySpecialWidget( YWidget *parent, YWidgetOpt & opt,
  * placeholder where the current value will be inserted (sformat() -style) and
  * newlines. If no labels are specified, only the values will be
  * displayed. Specify empty labels to suppress this.
- * @note        This is a "special" widget, i.e. not all UIs necessarily support it.  Check
+ * @note	This is a "special" widget, i.e. not all UIs necessarily support it.  Check
  * for availability with <tt>HasSpecialWidget( BarGraph )</tt> before using it.
  *
  **/
@@ -2794,7 +2776,7 @@ YCPDialogParser::parseBarGraph( YWidget *parent, YWidgetOpt & opt,
 
     if ( numArgs < 1 || numArgs > 2
 	 || ! term->value(argnr)->isList()
-	 || ( numArgs > 1 && ! term->value(argnr+1)->isList() )
+	 || ( numArgs > 1 && ! term->value( argnr+1 )->isList() )
 	 )
     {
 	THROW_BAD_ARGS( term );
@@ -2883,9 +2865,9 @@ YCPDialogParser::parseDownloadProgress( YWidget *parent, YWidgetOpt & opt,
     int numArgs = term->size() - argnr;
 
     if ( numArgs != 3
-	 || ! term->value(argnr  )->isString()
-	 || ! term->value(argnr+1)->isString()
-	 || ! term->value(argnr+2)->isInteger()
+	 || ! term->value(argnr	 )->isString()
+	 || ! term->value( argnr+1 )->isString()
+	 || ! term->value( argnr+2 )->isInteger()
 	 )
     {
 	THROW_BAD_ARGS( term );
@@ -2893,8 +2875,8 @@ YCPDialogParser::parseDownloadProgress( YWidget *parent, YWidgetOpt & opt,
 
     rejectAllOptions( term,optList );
 
-    string	label	 	= term->value( argnr   )->asString()->value();
-    string	filename 	= term->value( argnr+1 )->asString()->value();
+    string	label		= term->value( argnr   )->asString()->value();
+    string	filename	= term->value( argnr+1 )->asString()->value();
     YFileSize_t	expectedSize	= term->value( argnr+2 )->asInteger()->value();
 
     return YUI::optionalWidgetFactory()->createDownloadProgress( parent, label, filename, expectedSize );
@@ -2935,7 +2917,7 @@ YCPDialogParser::parseDownloadProgress( YWidget *parent, YWidgetOpt & opt,
  * initially selected. If you specify only a string, UI::UserInput() will
  * return this string.
  *
- * This is a "special" widget, i.e. not all UIs necessarily support it.  Check
+ * This is a "special" widget, i.e. not all UIs necessarily support it.	 Check
  * for availability with <tt>HasSpecialWidget( :DumbTab )</tt> before
  * using it.
  *
@@ -3024,7 +3006,7 @@ YCPDialogParser::parseDumbTab( YWidget *parent, YWidgetOpt & opt,
  * even if that means that some segments will be shown slightly out of
  * proportion.
  *
- * @note  This is a "special" widget, i.e. not all UIs necessarily support it.  Check
+ * @note  This is a "special" widget, i.e. not all UIs necessarily support it.	Check
  * for availability with <tt>HasSpecialWidget( :MultiProgressMeter )</tt> before using it.
  **/
 
@@ -3112,7 +3094,7 @@ YCPDialogParser::parseNumList( const YCPList & yList )
  * Remember you can use <tt>Opt( :notify )</tt> in order to get instant response
  * when the user changes the value - if this is desired.
  *
- * @note  This is a "special" widget, i.e. not all UIs necessarily support it.  Check
+ * @note  This is a "special" widget, i.e. not all UIs necessarily support it.	Check
  * for availability with <tt>HasSpecialWidget( :Slider )</tt> before using it.
  *
  **/
@@ -3124,10 +3106,10 @@ YCPDialogParser::parseSlider( YWidget *parent, YWidgetOpt & opt,
     int numArgs = term->size() - argnr;
 
     if ( numArgs != 4
-	 || ! term->value(argnr)->isString()
-	 || ! term->value(argnr+1)->isInteger()
-	 || ! term->value(argnr+2)->isInteger()
-	 || ! term->value(argnr+3)->isInteger()
+	 || ! term->value( argnr   )->isString()
+	 || ! term->value( argnr+1 )->isInteger()
+	 || ! term->value( argnr+2 )->isInteger()
+	 || ! term->value( argnr+3 )->isInteger()
 	 )
     {
 	THROW_BAD_ARGS( term );
@@ -3136,9 +3118,9 @@ YCPDialogParser::parseSlider( YWidget *parent, YWidgetOpt & opt,
     rejectAllOptions( term,optList );
 
     string	label		= term->value( argnr   )->asString()->value();
-    int 	minValue	= term->value( argnr+1 )->asInteger()->value();
-    int 	maxValue	= term->value( argnr+2 )->asInteger()->value();
-    int 	initialValue	= term->value( argnr+3 )->asInteger()->value();
+    int		minValue	= term->value( argnr+1 )->asInteger()->value();
+    int		maxValue	= term->value( argnr+2 )->asInteger()->value();
+    int		initialValue	= term->value( argnr+3 )->asInteger()->value();
 
     return YUI::optionalWidgetFactory()->createSlider( parent, label, minValue, maxValue, initialValue );
 }
@@ -3150,18 +3132,18 @@ YCPDialogParser::parseSlider( YWidget *parent, YWidgetOpt & opt,
  * @class	YPartitionSplitter
  *
  * @arg integer	usedSize		size of the used part of the partition
- * @arg integer	totalFreeSize 		total size of the free part of the partition
+ * @arg integer	totalFreeSize		total size of the free part of the partition
  *					(before the split)
  * @arg integer newPartSize		suggested size of the new partition
  * @arg integer minNewPartSize		minimum size of the new partition
  * @arg integer minFreeSize		minimum free size of the old partition
- * @arg string	usedLabel 		BarGraph label for the used part of the old partition
- * @arg string	freeLabel 		BarGraph label for the free part of the old partition
- * @arg string	newPartLabel  		BarGraph label for the new partition
+ * @arg string	usedLabel		BarGraph label for the used part of the old partition
+ * @arg string	freeLabel		BarGraph label for the free part of the old partition
+ * @arg string	newPartLabel		BarGraph label for the new partition
  * @arg string	freeFieldLabel		label for the remaining free space field
  * @arg string	newPartFieldLabel	label for the new size field
  *		PartitionSplitter( 600, 1200, 800, 300, 50,
- *                                 "Windows used\n%1 MB", "Windows used\n%1 MB", "Linux\n%1 MB", "Linux ( MB )" )
+ *				   "Windows used\n%1 MB", "Windows used\n%1 MB", "Linux\n%1 MB", "Linux ( MB )" )
  *
  * @example	PartitionSplitter1.rb
  * @example	PartitionSplitter2.rb
@@ -3192,16 +3174,16 @@ YCPDialogParser::parsePartitionSplitter( YWidget *parent, YWidgetOpt & opt,
     int numArgs = term->size() - argnr;
 
     if ( numArgs != 10
-	 || ! term->value(argnr  )->isInteger()	// usedSize
-	 || ! term->value(argnr+1)->isInteger()	// freeSize
-	 || ! term->value(argnr+2)->isInteger()	// newPartSize
-	 || ! term->value(argnr+3)->isInteger()	// minNewPartSize
-	 || ! term->value(argnr+4)->isInteger()	// minFreeSize
-	 || ! term->value(argnr+5)->isString()	// usedLabel
-	 || ! term->value(argnr+6)->isString()	// freeLabel
-	 || ! term->value(argnr+7)->isString()	// newPartLabel
-	 || ! term->value(argnr+8)->isString()	// freeFieldLabel
-	 || ! term->value(argnr+9)->isString()	// newPartFieldLabel
+	 || ! term->value( argnr   )->isInteger()       // usedSize
+	 || ! term->value( argnr+1 )->isInteger()	// freeSize
+	 || ! term->value( argnr+2 )->isInteger()	// newPartSize
+	 || ! term->value( argnr+3 )->isInteger()	// minNewPartSize
+	 || ! term->value( argnr+4 )->isInteger()	// minFreeSize
+	 || ! term->value( argnr+5 )->isString()	// usedLabel
+	 || ! term->value( argnr+6 )->isString()	// freeLabel
+	 || ! term->value( argnr+7 )->isString()	// newPartLabel
+	 || ! term->value( argnr+8 )->isString()	// freeFieldLabel
+	 || ! term->value( argnr+9 )->isString()	// newPartFieldLabel
 	 )
     {
 	THROW_BAD_ARGS( term );
@@ -3209,16 +3191,16 @@ YCPDialogParser::parsePartitionSplitter( YWidget *parent, YWidgetOpt & opt,
 
     rejectAllOptions( term, optList );
 
-    int 	usedSize		= term->value( argnr   )->asInteger()->value();
-    int 	totalFreeSize		= term->value( argnr+1 )->asInteger()->value();
-    int 	newPartSize		= term->value( argnr+2 )->asInteger()->value();
-    int 	minNewPartSize		= term->value( argnr+3 )->asInteger()->value();
-    int 	minFreeSize		= term->value( argnr+4 )->asInteger()->value();
-    string 	usedLabel		= term->value( argnr+5 )->asString()->value();
-    string 	freeLabel		= term->value( argnr+6 )->asString()->value();
-    string 	newPartLabel		= term->value( argnr+7 )->asString()->value();
-    string 	freeFieldLabel		= term->value( argnr+8 )->asString()->value();
-    string 	newPartFieldLabel	= term->value( argnr+9 )->asString()->value();
+    int		usedSize		= term->value( argnr   )->asInteger()->value();
+    int		totalFreeSize		= term->value( argnr+1 )->asInteger()->value();
+    int		newPartSize		= term->value( argnr+2 )->asInteger()->value();
+    int		minNewPartSize		= term->value( argnr+3 )->asInteger()->value();
+    int		minFreeSize		= term->value( argnr+4 )->asInteger()->value();
+    string	usedLabel		= term->value( argnr+5 )->asString()->value();
+    string	freeLabel		= term->value( argnr+6 )->asString()->value();
+    string	newPartLabel		= term->value( argnr+7 )->asString()->value();
+    string	freeFieldLabel		= term->value( argnr+8 )->asString()->value();
+    string	newPartFieldLabel	= term->value( argnr+9 )->asString()->value();
 
     return YUI::optionalWidgetFactory()->createPartitionSplitter( parent,
 								  usedSize,
@@ -3340,8 +3322,8 @@ YCPDialogParser::parseDateField( YWidget * parent, YWidgetOpt & opt,
 {
 
     if ( term->size() - argnr < 1 || term->size() - argnr > 2
-	 || !term->value(argnr)->isString()
-	 || (term->size() == argnr+2 && !term->value(argnr+1)->isString()))
+	 || ! term->value(argnr)->isString()
+	 || (term->size() == argnr+2 && ! term->value( argnr+1 )->isString()))
     {
 	THROW_BAD_ARGS( term );
     }
@@ -3370,7 +3352,7 @@ YCPDialogParser::parseDateField( YWidget * parent, YWidgetOpt & opt,
  * @class	YTimeField
  * @arg		string label
  * @optarg	string initialTime
- * 		    TimeField( "Time:" , "20:20:20" )
+ *		    TimeField( "Time:" , "20:20:20" )
  *
  *
  * An input field for entering a time of day in 24 hour format.
@@ -3384,8 +3366,8 @@ YCPDialogParser::parseTimeField( YWidget * parent, YWidgetOpt & opt,
 {
 
     if ( term->size() - argnr < 1 || term->size() - argnr > 2
-	 || !term->value(argnr)->isString()
-	 || (term->size() == argnr+2 && !term->value(argnr+1)->isString()))
+	 || ! term->value(argnr)->isString()
+	 || (term->size() == argnr+2 && ! term->value( argnr+1 )->isString()))
     {
 	THROW_BAD_ARGS( term );
     }
@@ -3443,7 +3425,7 @@ YCPDialogParser::parseWizard( YWidget * parent, YWidgetOpt & opt,
 			      const YCPTerm & term, const YCPList & optList, int argnr )
 {
     if ( term->size() - argnr != 6
-	 || ! isSymbolOrId( term->value( argnr   ) ) || ! term->value( argnr+1 )->isString()
+	 || ! isSymbolOrId( term->value( argnr	 ) ) || ! term->value( argnr+1 )->isString()
 	 || ! isSymbolOrId( term->value( argnr+2 ) ) || ! term->value( argnr+3 )->isString()
 	 || ! isSymbolOrId( term->value( argnr+4 ) ) || ! term->value( argnr+5 )->isString() )
     {
@@ -3457,14 +3439,14 @@ YCPDialogParser::parseWizard( YWidget * parent, YWidgetOpt & opt,
 
     for ( int o=0; o < optList->size(); o++ )
     {
-	if      ( optList->value(o)->isSymbol() && optList->value(o)->asSymbol()->symbol() == YUIOpt_stepsEnabled ) wizardMode = YWizardMode_Steps;
+	if	( optList->value(o)->isSymbol() && optList->value(o)->asSymbol()->symbol() == YUIOpt_stepsEnabled ) wizardMode = YWizardMode_Steps;
 	else if ( optList->value(o)->isSymbol() && optList->value(o)->asSymbol()->symbol() == YUIOpt_treeEnabled  ) wizardMode = YWizardMode_Tree;
 	else if ( optList->value(o)->isSymbol() && optList->value(o)->asSymbol()->symbol() == YUIOpt_titleOnLeft  ) wizardMode = YWizardMode_TitleOnLeft;
 	else logUnknownOption( term, optList->value(o) );
     }
 
     YWidgetID *	backButtonId		= new YCPValueWidgetID( parseIdTerm( term->value( argnr ) ) );
-    string	backButtonLabel 	= term->value( argnr+1 )->asString()->value();
+    string	backButtonLabel		= term->value( argnr+1 )->asString()->value();
 
     YWidgetID *	abortButtonId		= new YCPValueWidgetID( parseIdTerm( term->value( argnr+2 ) ) );
     string	abortButtonLabel	= term->value( argnr+3 )->asString()->value();
@@ -3487,9 +3469,9 @@ YCPDialogParser::parseWizard( YWidget * parent, YWidgetOpt & opt,
     // The wizard internal contents ReplacePoint has a fixed ID :contents
     YWidgetID * contentsId =  new YCPValueWidgetID( YCPSymbol( YWizardContentsReplacePointID ) );
 
-    if ( wizard->backButton()  ) 		wizard->backButton()->setId ( backButtonId  );
-    if ( wizard->abortButton() ) 		wizard->abortButton()->setId( abortButtonId );
-    if ( wizard->nextButton()  ) 		wizard->nextButton()->setId ( nextButtonId  );
+    if ( wizard->backButton()  )		wizard->backButton()->setId ( backButtonId  );
+    if ( wizard->abortButton() )		wizard->abortButton()->setId( abortButtonId );
+    if ( wizard->nextButton()  )		wizard->nextButton()->setId ( nextButtonId  );
     wizard->contentsReplacePoint()->setId( contentsId );
 
     return wizard;
@@ -3500,12 +3482,12 @@ YCPDialogParser::parseWizard( YWidget * parent, YWidgetOpt & opt,
  * @short	Timezone selector map
  * @class	YTimezoneSelector
  *
- * @arg		string pixmap     path to a jpg or png of a world map - with 0°0° being the
- *                                middle of the picture
- * @arg         map timezones     a map of timezones. The map should be between e.g. Europe/London
- *                                and the tooltip to be displayed ("United Kingdom")
+ * @arg		string pixmap	  path to a jpg or png of a world map - with 0°0° being the
+ *				  middle of the picture
+ * @arg		map timezones	  a map of timezones. The map should be between e.g. Europe/London
+ *				  and the tooltip to be displayed ("United Kingdom")
  *
- * 		    TimezoneSelector( "world.jpg", timezones )
+ *		    TimezoneSelector( "world.jpg", timezones )
  *
  *
  * An graphical timezone selector map
@@ -3515,11 +3497,11 @@ YCPDialogParser::parseWizard( YWidget * parent, YWidgetOpt & opt,
  **/
 YWidget *
 YCPDialogParser::parseTimezoneSelector( YWidget * parent, YWidgetOpt & opt,
-                                        const YCPTerm & term, const YCPList & optList, int argnr )
+					const YCPTerm & term, const YCPList & optList, int argnr )
 {
     if ( term->size() - argnr != 2
-	 || !term->value(argnr)->isString()
-         || !term->value(argnr+1)->isMap() )
+	 || ! term->value(argnr)->isString()
+	 || ! term->value( argnr+1 )->isMap() )
     {
 	THROW_BAD_ARGS( term );
     }
@@ -3530,7 +3512,7 @@ YCPDialogParser::parseTimezoneSelector( YWidget * parent, YWidgetOpt & opt,
     map<string,string> zones;
     YCPMap secondArg = term->value( argnr+1 )->asMap();
     for ( YCPMap::const_iterator it = secondArg.begin(); it != secondArg.end(); ++it )
-        zones[ it->first->asString()->value() ] = it->second->asString()->value();
+	zones[ it->first->asString()->value() ] = it->second->asString()->value();
 
     YTimezoneSelector * selector = YUI::optionalWidgetFactory()->createTimezoneSelector( parent, pixmap, zones );
 
@@ -3543,7 +3525,7 @@ YCPDialogParser::parseTimezoneSelector( YWidget * parent, YWidgetOpt & opt,
  * @short	graph
  * @class	YGraph
  *
- * 		    Graph( "graph.dot", "dot" )
+ *		    Graph( "graph.dot", "dot" )
  *
  *
  * An graph
@@ -3556,8 +3538,8 @@ YCPDialogParser::parseGraph( YWidget * parent, YWidgetOpt & opt,
 			     const YCPTerm & term, const YCPList & optList, int argnr )
 {
     if ( term->size() - argnr != 2
-	 || !term->value(argnr)->isString()
-	 || !term->value(argnr+1)->isString() )
+	 || ! term->value(argnr)->isString()
+	 || ! term->value( argnr+1 )->isString() )
     {
 	THROW_BAD_ARGS( term );
     }
@@ -3603,16 +3585,16 @@ YCPDialogParser::parseBusyIndicator( YWidget * parent, YWidgetOpt & opt,
     int s = term->size() - argnr;
     if ( s < 1
 	 || s > 2
-	 || (s >= 1 && !term->value(argnr)->isString())
-	 || (s >= 2 && !term->value(argnr+1)->isInteger()) )
+	 || ( s >= 1 && ! term->value(argnr)->isString()      )
+	 || ( s >= 2 && ! term->value( argnr+1 )->isInteger() ) )
     {
 	THROW_BAD_ARGS( term );
     }
 
     rejectAllOptions( term,optList );
 
-    string  label        = term->value( argnr )->asString()->value();
-    int	    timeout      = 1000;
+    string  label	 = term->value( argnr )->asString()->value();
+    int	    timeout	 = 1000;
 
     if ( s >= 2 ) timeout	= term->value( argnr+1 )->asInteger()->value();
 
@@ -3664,7 +3646,7 @@ YCPDialogParser::checkId( const YCPValue & v, bool complain )
     {
 	if ( complain )
 	{
-	    ycperror( "Expected `" YUISymbol_id "( any v ), not  %s", v->toString().c_str() );
+	    ycperror( "Expected `" YUISymbol_id "( any v ), not	 %s", v->toString().c_str() );
 	}
 	return false;
     }
@@ -3715,7 +3697,7 @@ YCPDialogParser::getWidgetId( const YCPTerm & term, int *argnr )
 	if ( findWidgetWithId( id,
 			       false ) ) // Don't throw exception if not found
 	{
-            // Already have a widget with that ID?
+	    // Already have a widget with that ID?
 	    ycperror( "Widget id %s is not unique", id->toString().c_str() );
 	    *argnr = 1;
 	    return YCPNull();

--- a/src/YCPDialogParser.cc
+++ b/src/YCPDialogParser.cc
@@ -137,9 +137,9 @@ using std::string;
  *				( if Opt( :notify ) is set for that SelectionBox ).
  *				Only widgets with this option set are affected.
  *
- * @option	notifyContextMenu Make this widget to send an event when the context menu is requested,
+ * @option	notifyContextMenu Make this widget send an event when the context menu is requested,
  *				e.g. when the user clicks the right mouse button.
- *				( if Opt( :notifyContextMenu ) is set for that SelectionBox ).
+ *				(if Opt( :notifyContextMenu ) is set for that widget).
  *				Only widgets with this option set are affected.
  *
  * @option	disabled	Set this widget insensitive, i.e. disable any user interaction.
@@ -285,6 +285,7 @@ YCPDialogParser::parseWidgetTreeTerm( YWidget *		p,
     else if ( s == YUIWidget_MinHeight		)	w = parseMinSize		( p, opt, term, ol, n, false, true  );
     else if ( s == YUIWidget_MinSize		)	w = parseMinSize		( p, opt, term, ol, n, true,  true  );
     else if ( s == YUIWidget_MinWidth		)	w = parseMinSize		( p, opt, term, ol, n, true,  false );
+    else if ( s == YUIWidget_MultiItemSelector  )	w = parseItemSelector           ( p, opt, term, ol, n, false );
     else if ( s == YUIWidget_MultiLineEdit	)	w = parseMultiLineEdit		( p, opt, term, ol, n );
     else if ( s == YUIWidget_MultiSelectionBox	)	w = parseMultiSelectionBox	( p, opt, term, ol, n );
     else if ( s == YUIWidget_PackageSelector	)	w = parsePackageSelector	( p, opt, term, ol, n );
@@ -298,6 +299,7 @@ YCPDialogParser::parseWidgetTreeTerm( YWidget *		p,
     else if ( s == YUIWidget_RichText		)	w = parseRichText		( p, opt, term, ol, n );
     else if ( s == YUIWidget_Right		)	w = parseAlignment		( p, opt, term, ol, n, YAlignEnd,	YAlignUnchanged );
     else if ( s == YUIWidget_SelectionBox	)	w = parseSelectionBox		( p, opt, term, ol, n );
+    else if ( s == YUIWidget_SingleItemSelector )	w = parseItemSelector           ( p, opt, term, ol, n, true );
     else if ( s == YUIWidget_Table		)	w = parseTable			( p, opt, term, ol, n );
     else if ( s == YUIWidget_TextEntry		)	w = parseInputField		( p, opt, term, ol, n, false, true ); // bugCompatibilityMode
     else if ( s == YUIWidget_Top		)	w = parseAlignment		( p, opt, term, ol, n, YAlignUnchanged,	YAlignBegin	);
@@ -439,7 +441,7 @@ YCPDialogParser::parseReplacePoint( YWidget * parent, YWidgetOpt & opt, const YC
 	THROW_BAD_ARGS( term );
     }
 
-    rejectAllOptions( term,optList );
+    rejectAllOptions( term, optList );
 
     YReplacePoint * replacePoint = YUI::widgetFactory()->createReplacePoint( parent );
     parseWidgetTreeTerm( replacePoint, term->value( argnr )->asTerm() );
@@ -468,7 +470,7 @@ YCPDialogParser::parseEmpty( YWidget * parent, YWidgetOpt & opt,
 	THROW_BAD_ARGS( term );
     }
 
-    rejectAllOptions( term,optList );
+    rejectAllOptions( term, optList );
 
     return YUI::widgetFactory()->createEmpty( parent );
 }
@@ -542,7 +544,7 @@ YCPDialogParser::parseSpacing( YWidget * parent, YWidgetOpt & opt,
 	THROW_BAD_ARGS( term );
     }
 
-    rejectAllOptions( term,optList );
+    rejectAllOptions( term, optList );
 
     return YUI::widgetFactory()->createSpacing( parent, dim, stretchable, size );
 }
@@ -880,7 +882,7 @@ YCPDialogParser::parseSquash( YWidget * parent, YWidgetOpt & opt,
 	THROW_BAD_ARGS( term );
     }
 
-    rejectAllOptions( term,optList );
+    rejectAllOptions( term, optList );
     YSquash * squash = YUI::widgetFactory()->createSquash( parent, horSquash, vertSquash );
     parseWidgetTreeTerm( squash, term->value( argnr )->asTerm() );
 
@@ -931,7 +933,8 @@ YCPDialogParser::parseWeight( YWidget * parent, YWidgetOpt & opt,
     {
 	THROW_BAD_ARGS( term );
     }
-    rejectAllOptions( term,optList );
+
+    rejectAllOptions( term, optList );
 
     // Create child widget tree
     YWidget * child = parseWidgetTreeTerm( parent, term->value( argnr+1 )->asTerm() );
@@ -1344,7 +1347,7 @@ YCPDialogParser::parseLogView( YWidget * parent, YWidgetOpt & opt,
 	THROW_BAD_ARGS( term );
     }
 
-    rejectAllOptions( term,optList );
+    rejectAllOptions( term, optList );
 
     string	label		= term->value( argnr   )->asString()->value();
     int		visibleLines	= term->value( argnr+1 )->asInteger()->value();
@@ -1529,7 +1532,7 @@ YCPDialogParser::parseMenuButton( YWidget * parent, YWidgetOpt & opt,
 	THROW_BAD_ARGS( term );
     }
 
-    rejectAllOptions( term,optList );
+    rejectAllOptions( term, optList );
 
     string label   = term->value( argnr )->asString()->value();
 
@@ -1576,7 +1579,8 @@ YCPDialogParser::parseCheckBox( YWidget * parent, YWidgetOpt & opt,
     {
 	THROW_BAD_ARGS( term );
     }
-    rejectAllOptions( term,optList );
+
+    rejectAllOptions( term, optList );
 
     string label   = term->value( argnr )->asString()->value();
     bool   checked = false;
@@ -1692,8 +1696,7 @@ YCPDialogParser::parseCheckBoxFrame( YWidget * parent, YWidgetOpt & opt,
  * @example	ShortcutConflict3.rb
  *
  *
- *
- * A radio button is not usefull alone. Radio buttons are group such that the
+ * A radio button is not useful alone. Radio buttons are group such that the
  * user can select one radio button of a group. It is much like a selection
  * box, but radio buttons can be dispersed over the dialog.  Radio buttons must
  * be contained in a <tt>RadioButtonGroup</tt>.
@@ -1712,7 +1715,7 @@ YCPDialogParser::parseRadioButton( YWidget * parent, YWidgetOpt & opt,
 	THROW_BAD_ARGS( term );
     }
 
-    rejectAllOptions( term,optList );
+    rejectAllOptions( term, optList );
 
     string label     = term->value( argnr )->asString()->value();
     bool   isChecked = false;
@@ -1761,7 +1764,7 @@ YCPDialogParser::parseRadioButtonGroup( YWidget * parent, YWidgetOpt & opt,
 	THROW_BAD_ARGS( term );
     }
 
-    rejectAllOptions( term,optList );
+    rejectAllOptions( term, optList );
 
     YRadioButtonGroup * radioButtonGroup = YUI::widgetFactory()->createRadioButtonGroup( parent );
     parseWidgetTreeTerm( radioButtonGroup, term->value( argnr )->asTerm() );
@@ -1991,12 +1994,12 @@ YCPDialogParser::parseSelectionBox( YWidget * parent, YWidgetOpt & opt,
  *
  *
  *
- * The MultiSelectionBox displays a ( scrollable ) list of items from which any
+ * The MultiSelectionBox displays a (scrollable) list of items from which any
  * number (even nothing!) can be selected. Use the MultiSelectionBox's
  * <tt>SelectedItems</tt> property to find out which.
  *
  * Each item can be specified either as a simple string or as
- * <tt>Item( ... )</tt> which includes an ( optional ) ID and an (optional)
+ * <tt>Item( ... )</tt> which includes an (optional) ID and an (optional)
  * 'selected' flag that specifies the initial selected state ('not selected',
  * i.e. 'false', is default).
  *
@@ -2009,7 +2012,7 @@ YCPDialogParser::parseMultiSelectionBox( YWidget * parent, YWidgetOpt & opt,
     int numargs = term->size() - argnr;
 
     if ( numargs < 1 || numargs > 2
-	 || ! term->value( argnr   )->isString()
+	 || ! term->value( argnr )->isString()
 	 || ( numargs >= 2 && ! term->value( argnr+1 )->isList() ) )
     {
 	THROW_BAD_ARGS( term );
@@ -2038,6 +2041,55 @@ YCPDialogParser::parseMultiSelectionBox( YWidget * parent, YWidgetOpt & opt,
     return multiSelectionBox;
 }
 
+
+/**
+ * @widget	SingleItemSelector MultiItemSelector
+ * @short	Scrollable list of radio buttons or check boxes with a description text
+ * @class	YItemSelector
+ * @optarg	list	items	the initial items
+ * @example	SingleItemselector1.rb
+ * @example	MultiItemselector1.rb
+ *
+ *
+ * This is a scrollable list of radio buttons (SingleItemSelector) or check
+ * boxes (MultiItemSelector) with not only a one-line label for each, but an
+ * additional text block (the description) below each one and an optional icon.
+ *
+ * The desired initial number of visible items (by default 3) can be configured with
+ * the <tt>VisibleItems<tt> property. When changing that, remember to
+ * recalculate the layout with <<RecalcLayout</tt>.
+ *
+ * The <tt>Value</tt> property returns the first selected item in both modes
+ * (single or multi selection), <tt>SelectedItems</tt> returns them all.
+ *
+ * Notice that in a SingleItemSelector always has one selected item, while a
+ * MultiItemSelector may also have none.
+ **/
+YWidget *
+YCPDialogParser::parseItemSelector( YWidget *parent, YWidgetOpt & opt,
+                                    const YCPTerm & term, const YCPList & optList, int argnr,
+                                    bool singleSelection )
+{
+    int numargs = term->size() - argnr;
+
+    if ( numargs > 1 ||
+         ( numargs == 1 && ! term->value( argnr )->isList() ) )
+    {
+	THROW_BAD_ARGS( term );
+    }
+
+    rejectAllOptions( term, optList );
+
+    YItemSelector * itemSelector = YUI::widgetFactory()->createItemSelector( parent, singleSelection );
+
+    if ( numargs == 1 )
+    {
+	YCPList itemList = term->value( argnr )->asList();
+	itemSelector->addItems( YCPItemParser::parseItemList( itemList ) );
+    }
+
+    return itemSelector;
+}
 
 
 
@@ -2079,6 +2131,7 @@ YCPDialogParser::parseComboBox( YWidget * parent, YWidgetOpt & opt,
 				const YCPTerm & term, const YCPList & optList, int argnr )
 {
     int numargs = term->size() - argnr;
+
     if ( numargs < 1 || numargs > 2
 	 || ! term->value(argnr)->isString()
 	 || ( numargs >= 2 && ! term->value( argnr+1 )->isList() ) )
@@ -2307,6 +2360,7 @@ YCPDialogParser::parseTable( YWidget * parent, YWidgetOpt & opt,
 			     const YCPTerm & term, const YCPList & optList, int argnr )
 {
     int numArgs = term->size() - argnr;
+
     if ( numArgs < 1 || numArgs > 2
 	 || ! term->value(argnr)->isTerm()
 	 || term->value(argnr)->asTerm()->name() != YUISymbol_header
@@ -2451,7 +2505,7 @@ YCPDialogParser::parseProgressBar( YWidget * parent, YWidgetOpt & opt,
 	THROW_BAD_ARGS( term );
     }
 
-    rejectAllOptions( term,optList );
+    rejectAllOptions( term, optList );
 
     string  label	 = term->value( argnr )->asString()->value();
     int	    maxValue	 = 100;
@@ -2603,7 +2657,7 @@ YCPDialogParser::parseIntField( YWidget * parent, YWidgetOpt & opt,
 	THROW_BAD_ARGS( term );
     }
 
-    rejectAllOptions( term,optList );
+    rejectAllOptions( term, optList );
 
     string	label		= term->value( argnr   )->asString()->value();
     int		minValue	= term->value( argnr+1 )->asInteger()->value();
@@ -2712,7 +2766,7 @@ YCPDialogParser::parsePkgSpecial( YWidget * parent, YWidgetOpt & opt,
 	THROW_BAD_ARGS( term );
     }
 
-    rejectAllOptions( term,optList );
+    rejectAllOptions( term, optList );
     string subwidgetName = term->value( argnr )->asString()->value();
 
     return YUI::widgetFactory()->createPkgSpecial( parent, subwidgetName );
@@ -2782,7 +2836,7 @@ YCPDialogParser::parseBarGraph( YWidget *parent, YWidgetOpt & opt,
 	THROW_BAD_ARGS( term );
     }
 
-    rejectAllOptions( term,optList );
+    rejectAllOptions( term, optList );
 
     YBarGraph * barGraph = YUI::optionalWidgetFactory()->createBarGraph( parent );
     YBarGraphMultiUpdate multiUpdate( barGraph ); // Hold back display updates
@@ -2873,7 +2927,7 @@ YCPDialogParser::parseDownloadProgress( YWidget *parent, YWidgetOpt & opt,
 	THROW_BAD_ARGS( term );
     }
 
-    rejectAllOptions( term,optList );
+    rejectAllOptions( term, optList );
 
     string	label		= term->value( argnr   )->asString()->value();
     string	filename	= term->value( argnr+1 )->asString()->value();
@@ -2965,7 +3019,7 @@ YCPDialogParser::parseDumbTab( YWidget *parent, YWidgetOpt & opt,
     YCPList itemList  = term->value( argnr   )->asList();
     YCPTerm childTerm = term->value( argnr+1 )->asTerm();
 
-    rejectAllOptions( term,optList );
+    rejectAllOptions( term, optList );
 
     YDumbTab * dumbTab = YUI::optionalWidgetFactory()->createDumbTab( parent );
     dumbTab->addItems( YCPItemParser::parseItemList( itemList ) ); // Add tab pages
@@ -3039,7 +3093,7 @@ YCPDialogParser::parseMultiProgressMeter( YWidget *parent, YWidgetOpt & opt,
 						  term->value( argnr ) ) );
     }
 
-    rejectAllOptions( term,optList );
+    rejectAllOptions( term, optList );
 
     return YUI::optionalWidgetFactory()->createMultiProgressMeter( parent, dim, maxValues );
 }
@@ -3115,7 +3169,7 @@ YCPDialogParser::parseSlider( YWidget *parent, YWidgetOpt & opt,
 	THROW_BAD_ARGS( term );
     }
 
-    rejectAllOptions( term,optList );
+    rejectAllOptions( term, optList );
 
     string	label		= term->value( argnr   )->asString()->value();
     int		minValue	= term->value( argnr+1 )->asInteger()->value();
@@ -3329,7 +3383,7 @@ YCPDialogParser::parseDateField( YWidget * parent, YWidgetOpt & opt,
     }
 
 
-    rejectAllOptions( term,optList );
+    rejectAllOptions( term, optList );
 
     string label = term->value( argnr )->asString()->value();
 
@@ -3372,7 +3426,7 @@ YCPDialogParser::parseTimeField( YWidget * parent, YWidgetOpt & opt,
 	THROW_BAD_ARGS( term );
     }
 
-    rejectAllOptions( term,optList );
+    rejectAllOptions( term, optList );
 
     string label = term->value( argnr )->asString()->value();
 
@@ -3591,7 +3645,7 @@ YCPDialogParser::parseBusyIndicator( YWidget * parent, YWidgetOpt & opt,
 	THROW_BAD_ARGS( term );
     }
 
-    rejectAllOptions( term,optList );
+    rejectAllOptions( term, optList );
 
     string  label	 = term->value( argnr )->asString()->value();
     int	    timeout	 = 1000;

--- a/src/YCPDialogParser.cc
+++ b/src/YCPDialogParser.cc
@@ -46,22 +46,21 @@ you may find current contact information at www.novell.com
 
 #include "YCPDialogParser.h"
 
-#include <yui/YUI.h>
-#include <yui/YApplication.h>
-#include "YCP_util.h"
-#include <yui/YUISymbols.h>
-#include <yui/YWidget.h>
-#include "YCPValueWidgetID.h"
 #include "YCPItemParser.h"
 #include "YCPMenuItemParser.h"
-#include "YCPTreeItemParser.h"
 #include "YCPTableItemParser.h"
+#include "YCPTreeItemParser.h"
+#include "YCPValueWidgetID.h"
 #include "YCP_UI_Exception.h"
-#include <yui/YDialog.h>
+#include "YCP_util.h"
+#include "YWidgetOpt.h"
+
+#include <yui/YUI.h>
+#include <yui/YUISymbols.h>
+#include <yui/YApplication.h>
 #include <yui/YWidgetFactory.h>
 #include <yui/YOptionalWidgetFactory.h>
-#include <yui/YBothDim.h>
-#include "YWidgetOpt.h"
+#include <yui/YDialog.h>
 
 #include <yui/YAlignment.h>
 #include <yui/YBarGraph.h>
@@ -79,6 +78,7 @@ you may find current contact information at www.novell.com
 #include <yui/YImage.h>
 #include <yui/YInputField.h>
 #include <yui/YIntField.h>
+#include <yui/YItemSelector.h>
 #include <yui/YLabel.h>
 #include <yui/YLayoutBox.h>
 #include <yui/YLogView.h>
@@ -137,8 +137,8 @@ using std::string;
  *				( if Opt( :notify ) is set for that SelectionBox ).
  *				Only widgets with this option set are affected.
  *
- * @option	notifyContextMenu Make this widget to send an event when the context menu is requested
- *				e.g. when the user clicks right mouse button
+ * @option	notifyContextMenu Make this widget to send an event when the context menu is requested,
+ *				e.g. when the user clicks the right mouse button.
  *				( if Opt( :notifyContextMenu ) is set for that SelectionBox ).
  *				Only widgets with this option set are affected.
  *

--- a/src/YCPDialogParser.cc
+++ b/src/YCPDialogParser.cc
@@ -2090,7 +2090,7 @@ YCPDialogParser::parseItemSelector( YWidget *parent, YWidgetOpt & opt,
     if ( numargs == 1 )
     {
 	YCPList itemList = term->value( argnr )->asList();
-	itemSelector->addItems( YCPItemParser::parseItemList( itemList ) );
+	itemSelector->addItems( YCPItemParser::parseDescribedItemList( itemList ) );
     }
 
     return itemSelector;

--- a/src/YCPDialogParser.cc
+++ b/src/YCPDialogParser.cc
@@ -256,6 +256,11 @@ YCPDialogParser::parseWidgetTreeTerm( YWidget *		p,
     YWidget * w	= 0;
     string    s	= term->name();
 
+    // If you add a new widget here, make sure to also adapt ui_shortcuts.rb
+    // in the yast-ruby-bindings package!
+    //
+    // https://github.com/yast/yast-ruby-bindings/blob/master/src/ruby/yast/ui_shortcuts.rb
+
     if	    ( s == YUIWidget_Bottom		)	w = parseAlignment		( p, opt, term, ol, n, YAlignUnchanged,	YAlignEnd	);
     else if ( s == YUIWidget_BusyIndicator	)	w = parseBusyIndicator		( p, opt, term, ol, n );
     else if ( s == YUIWidget_ButtonBox		)	w = parseButtonBox		( p, opt, term, ol, n );

--- a/src/YCPDialogParser.h
+++ b/src/YCPDialogParser.h
@@ -222,6 +222,10 @@ protected:
     static YWidget * parseMultiSelectionBox( YWidget *parent, YWidgetOpt & opt,
 					     const YCPTerm & term, const YCPList & optList, int argnr );
 
+    static YWidget * parseItemSelector( YWidget *parent, YWidgetOpt & opt,
+                                        const YCPTerm & term, const YCPList & optList, int argnr,
+                                        bool singleSelection );
+
     static YWidget * parseComboBox( YWidget *parent, YWidgetOpt & opt,
 				    const YCPTerm & term, const YCPList & optList, int argnr );
 
@@ -279,14 +283,14 @@ protected:
     static YWidget * parseSimplePatchSelector( YWidget *parent, YWidgetOpt & opt, const YCPTerm & term,
 					       const YCPList & optList, int argnr );
 
-    static YWidget * parseTimezoneSelector ( YWidget *parent, YWidgetOpt & opt, const YCPTerm & term,
-					     const YCPList & optList, int argnr );
+    static YWidget * parseTimezoneSelector( YWidget *parent, YWidgetOpt & opt, const YCPTerm & term,
+                                            const YCPList & optList, int argnr );
 
-    static YWidget * parseGraph ( YWidget *parent, YWidgetOpt & opt, const YCPTerm & term,
-				  const YCPList & optList, int argnr );
+    static YWidget * parseGraph( YWidget *parent, YWidgetOpt & opt, const YCPTerm & term,
+                                 const YCPList & optList, int argnr );
 
     static YWidget * parseBusyIndicator( YWidget *parent, YWidgetOpt & opt,
-				       const YCPTerm & term, const YCPList & optList, int argnr );
+                                         const YCPTerm & term, const YCPList & optList, int argnr );
     /**
      * Look for a widget id in a widget term. If it finds one, returns
      * it and sets argnr to point after `id(), whether it turned out valid

--- a/src/YCPItem.h
+++ b/src/YCPItem.h
@@ -31,31 +31,33 @@ you may find current contact information at www.novell.com
 
 #include <ycp/YCPValue.h>
 #include <ycp/YCPString.h>
-#include <yui/YItem.h>
+#include <yui/YDescribedItem.h>
 
 
 /**
  * Item class with YCPValue IDs
  **/
-class YCPItem: public YItem
+class YCPItem: public YDescribedItem
 {
 public:
 
     /**
      * Constructors
      **/
-    YCPItem( const YCPString & 	label,
-	     const YCPValue  & 	id,
-	     bool  		selected = false )
-	: YItem( label->value(), selected )
-	, _id( id )
+    YCPItem( const YCPString &	label )
+	: YDescribedItem( label->value() )
+	, _id( label )
 	{}
 
-    YCPItem( const YCPString &	label,
-	     const YCPValue  & 	id,
+    YCPItem( const YCPValue  & 	id,
+             const YCPString &	label,
+             const YCPString &  description,
 	     const YCPString & 	iconName,
 	     bool  		selected = false )
-	: YItem( label->value(), iconName->value(), selected )
+	: YDescribedItem( label->value(),
+                          description->value(),
+                          iconName->value(),
+                          selected )
 	, _id( id )
 	{}
 
@@ -83,7 +85,7 @@ public:
     /**
      * Return this item's label as a YCPString.
      **/
-    YCPString label() const { return YCPString( YItem::label() ); }
+    YCPString label() const { return YCPString( YDescribedItem::label() ); }
 
     /**
      * Set this item's label with a YCPString.
@@ -92,15 +94,26 @@ public:
 	{ YItem::setLabel( newLabel->value() ); }
 
     /**
+     * Return this item's description as a YCPString.
+     **/
+    YCPString description() const { return YCPString( YDescribedItem::description() ); }
+
+    /**
+     * Set this item's description with a YCPString.
+     **/
+    void setDescription( const YCPString & newDescription )
+        { YDescribedItem::setDescription( newDescription->value() ); }
+
+    /**
      * Return this item's icon name as a YCPString.
      **/
-    YCPString iconName() const { return YCPString( YItem::iconName() ); }
+    YCPString iconName() const { return YCPString( YDescribedItem::iconName() ); }
 
     /**
      * Set this item's icon name with a YCPString.
      **/
     void setIconName( const YCPString & newIconName )
-	{ YItem::setIconName( newIconName->value() ); }
+	{ YDescribedItem::setIconName( newIconName->value() ); }
 
 
 private:

--- a/src/YCPItemParser.h
+++ b/src/YCPItemParser.h
@@ -43,11 +43,18 @@ public:
     /**
      * Parse an item list:
      *
-     *     [
-     *         `item(`id( `myID1 ), "Label1" ),
-     *         `item(`id( `myID2 ), `icon( "icon2.png"), "Label2", true ),
-     *         "Label3"
-     *     ]
+     *	   [
+     *	       `item(`id( `myID1 ), "Label1" ),
+     *	       `item(`id( `myID2 ), `icon( "icon2.png"), "Label2", true ),
+     *	       "Label3"
+     *	   ]
+     *
+     * If 'allowDescription' is true, also accept (in addition to above):
+     *
+     *	   [
+     *	       `item(`id( `myID1 ), "Label1", "Description1" ),
+     *	       `item(`id( `myID2 ), `icon( "icon2.png"), "Label2", "Description2", true ),
+     *	   ]
      *
      * Return a list of newly created YItem-derived objects.
      *
@@ -55,29 +62,53 @@ public:
      **/
     static YItemCollection parseItemList( const YCPList & ycpItemList );
 
+    /**
+     * Parse an item list with (optional) descriptions for each item:
+     *
+     *	   [
+     *	       `item(`id( `myID1 ), "Label1", "Description1" ),
+     *	       `item(`id( `myID2 ), `icon( "icon2.png"), "Label2", "Description2", true ),
+     *	       `item(`id( `myID3 ), `icon( "icon3.png"), "Label3" ),
+     *	       "Label4"
+     *	   ]
+     *
+     * Return a list of newly created YItem-derived objects.
+     *
+     * This function throws exceptions if there are syntax errors.
+     **/
+    static YItemCollection parseDescribedItemList( const YCPList & ycpItemList );
+
+
+protected:
+
+
+    /**
+     * Internal version of the item parser that supports plain YItems and YDescribedItems.
+     **/
+    static YItemCollection parseItemListInternal( const YCPList & ycpItemList,
+                                                  bool		  allowDescription = false );
+
+    /**
+     * Parse an item term:
+     *
+     *	       `item(`id( `myID1 ), "Label1" )
+     *	       `item(`id( `myID2 ), `icon( "icon2.png"), "Label2", true )
+     *
+     * Everything except the label is optional.
+     *
+     * This function throws exceptions if there are syntax errors.
+     **/
+    static YCPItem *    parseItem( const YCPTerm &      itemTerm,
+                                   bool                 allowDescription );
 
     /**
      * Parse one item and create a YCPItem from it.
      *
      * This function throws exceptions if there are syntax errors.
      **/
-    static YCPItem   * parseItem( const YCPValue & item );
+    static YCPItem *    parseItem( const YCPValue &	item,
+                                   bool			allowDescription );
 
-protected:
-
-    /**
-     * Parse an item term:
-     *
-     *         `item(`id( `myID1 ), "Label1" )
-     *         `item(`id( `myID2 ), `icon( "icon2.png"), "Label2", true )
-     *
-     * Everything except the label is optional.
-     *
-     * This function throws exceptions if there are syntax errors.
-     **/
-    static YCPItem * parseItem( const YCPTerm & itemTerm );
-
-    
 };
 
 

--- a/src/YCPItemWriter.cc
+++ b/src/YCPItemWriter.cc
@@ -33,7 +33,27 @@ you may find current contact information at www.novell.com
 
 
 YCPList
-YCPItemWriter::itemList( YItemConstIterator begin, YItemConstIterator end )
+YCPItemWriter::itemList( YItemConstIterator	begin,
+                         YItemConstIterator	end )
+{
+    return itemListInternal( begin, end,
+                             false ); // withDescription
+}
+
+
+YCPList
+YCPItemWriter::describedItemList( YItemConstIterator	begin,
+                                  YItemConstIterator	end )
+{
+    return itemListInternal( begin, end,
+                             true ); // withDescription
+}
+
+
+YCPList
+YCPItemWriter::itemListInternal( YItemConstIterator	begin,
+                                 YItemConstIterator	end,
+                                 bool			withDescription )
 {
     YCPList itemList;
 
@@ -43,7 +63,7 @@ YCPItemWriter::itemList( YItemConstIterator begin, YItemConstIterator end )
 
 	if ( item )
 	{
-	    itemList->add( itemTerm( item ) );
+	    itemList->add( itemTerm( item, withDescription ) );
 	}
     }
 
@@ -52,32 +72,45 @@ YCPItemWriter::itemList( YItemConstIterator begin, YItemConstIterator end )
 
 
 YCPValue
-YCPItemWriter::itemTerm( const YItem * item )
+YCPItemWriter::itemTerm( const YItem * item, bool withDescription )
 {
     if ( ! item )
 	return YCPVoid();
 
-    YCPTerm itemTerm( YUISymbol_item );	// `item()
+    YCPTerm itemTerm( YUISymbol_item );                 // `item()
 
     const YCPItem * ycpItem = dynamic_cast<const YCPItem *> (item);
 
     if ( ycpItem && ycpItem->hasId() )
     {
-	YCPTerm idTerm( YUISymbol_id );			// `id()
+	YCPTerm idTerm( YUISymbol_id );                 // `id()
 	idTerm->add( ycpItem->id() );
 	itemTerm->add( idTerm );
     }
 
     if ( item->hasIconName() )
     {
-	YCPTerm iconTerm( YUISymbol_icon );		// `icon()
+	YCPTerm iconTerm( YUISymbol_icon );             // `icon()
 	iconTerm->add( YCPString( item->iconName() ) );
 	itemTerm->add( iconTerm );
     }
 
-    itemTerm->add( YCPString( item->label() ) );	// label
+    itemTerm->add( YCPString( item->label() ) );        // label
 
-    if ( item->selected() )				// isSelected
+    if ( withDescription )
+    {
+        string description;
+
+        const YDescribedItem * describedItem = dynamic_cast<const YDescribedItem *>( item );
+
+        if ( describedItem )
+            description = describedItem->description();
+
+        itemTerm->add( YCPString( description ) );      // description
+
+    }
+
+    if ( item->selected() )                             // isSelected
 	itemTerm->add( YCPBoolean( item->selected() ) );
 
     return itemTerm;

--- a/src/YCPItemWriter.h
+++ b/src/YCPItemWriter.h
@@ -37,7 +37,8 @@ you may find current contact information at www.novell.com
 
 
 /**
- * Writer for SelectionBox, ComboBox, MultiSelectionBox item lists
+ * Writer for SelectionBox, ComboBox, MultiSelectionBox, SingleItemSelector,
+ * MultiItemSelector item lists
  **/
 class YCPItemWriter
 {
@@ -52,12 +53,32 @@ public:
      *         `item(`id( `myID3 ), `icon( "icon3.png"), "Label3", true )
      *     ]
      *
+     *
      * Note that the simple version "Label4" (without `item() and `id()) is
      * never returned here since if no ID is explicitly specified, the label
      * itself is used as the ID, so every item always has an ID, so the `id()
      * term and thus the `item() term have to be used.
      **/
-    static YCPList itemList( YItemConstIterator begin, YItemConstIterator end );
+    static YCPList itemList( YItemConstIterator begin,
+                             YItemConstIterator end );
+
+    /**
+     * Create a YCPList from an item collection:
+     *
+     *     [
+     *         `item(`id( `myID1 ), "Label1", "Description1" ),
+     *         `item(`id( `myID2 ), "Label2", "Description2", true ),
+     *         `item(`id( `myID3 ), `icon( "icon3.png"), "Label3", "Description3", true )
+     *     ]
+     *
+     *
+     * Note that the simple version "Label4" (without `item() and `id()) is
+     * never returned here since if no ID is explicitly specified, the label
+     * itself is used as the ID, so every item always has an ID, so the `id()
+     * term and thus the `item() term have to be used.
+     **/
+    static YCPList describedItemList( YItemConstIterator begin,
+                                      YItemConstIterator end );
 
 
     /**
@@ -67,8 +88,16 @@ public:
      *         `item(`id( `myID2 ), "Label2", true )
      *         `item(`id( `myID3 ), `icon( "icon3.png"), "Label3", true )
      **/
-    static YCPValue itemTerm( const YItem * item );
+    static YCPValue itemTerm( const YItem * item, bool withDescription );
 
+protected:
+
+    /**
+     * Create a YCPList from an item collection, either with or without description.
+     **/
+    static YCPList itemListInternal( YItemConstIterator begin,
+                                     YItemConstIterator end,
+                                     bool               allowDescription );
 };
 
 

--- a/src/YCPPropertyHandler.h
+++ b/src/YCPPropertyHandler.h
@@ -1,6 +1,7 @@
 /****************************************************************************
 
 Copyright (c) 2000 - 2010 Novell, Inc.
+Copyright (c) 2019 SUSE LLC
 All Rights Reserved.
 
 This program is free software; you can redistribute it and/or
@@ -24,7 +25,7 @@ you may find current contact information at www.novell.com
 
 		Widget property handlers for not-so-trivial properties.
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 
@@ -104,6 +105,7 @@ protected:
      **/
     static bool trySetCheckBoxValue			( YWidget * widget, const YCPValue & val );
     static bool trySetSelectionBoxValue			( YWidget * widget, const YCPValue & val );
+    static bool trySetItemSelectorValue			( YWidget * widget, const YCPValue & val );
     static bool trySetTreeValue				( YWidget * widget, const YCPValue & val );
     static bool trySetTableValue			( YWidget * widget, const YCPValue & val );
     static bool trySetDumbTabValue			( YWidget * widget, const YCPValue & val );
@@ -112,9 +114,11 @@ protected:
     static bool trySetTreeItems				( YWidget * widget, const YCPValue & val );
     static bool trySetTableItems			( YWidget * widget, const YCPValue & val );
     static bool trySetTableCell				( YWidget * widget, const YCPTerm  & propTerm, const YCPValue & val );
+    static bool trySetItemSelectorItems                 ( YWidget * widget, const YCPValue & val );
     static bool trySetSelectionWidgetItems		( YWidget * widget, const YCPValue & val );
     static bool trySetRadioButtonGroupCurrentButton	( YWidget * widget, const YCPValue & val );
     static bool trySetMultiSelectionBoxSelectedItems	( YWidget * widget, const YCPValue & val );
+    static bool trySetItemSelectorSelectedItems         ( YWidget * widget, const YCPValue & val );
     static bool trySetTableSelectedItems		( YWidget * widget, const YCPValue & val );
     static bool trySetTreeSelectedItems			( YWidget * widget, const YCPValue & val );
     static bool trySetMultiSelectionBoxCurrentItem	( YWidget * widget, const YCPValue & val );
@@ -123,19 +127,21 @@ protected:
     static bool trySetBarGraphLabels			( YWidget * widget, const YCPValue & val );
 
     /**
-     * All trySet..() functions try to dynamic_cast 'widget' to the expected
+     * All tryGet..() functions try to dynamic_cast 'widget' to the expected
      * widget type and then retrieve a property.
      *
      * They all return YCPNull upon failure and a non-null YCPValue upon success.
      **/
     static YCPValue tryGetCheckBoxValue			( YWidget * widget );
     static YCPValue tryGetSelectionBoxValue		( YWidget * widget );
+    static YCPValue tryGetItemSelectorValue		( YWidget * widget );
     static YCPValue tryGetTreeValue			( YWidget * widget );
     static YCPValue tryGetTableValue			( YWidget * widget );
     static YCPValue tryGetDumbTabValue			( YWidget * widget );
     static YCPValue tryGetComboBoxValue			( YWidget * widget );
     static YCPValue tryGetRadioButtonGroupCurrentButton	( YWidget * widget );
     static YCPValue tryGetMultiSelectionBoxSelectedItems( YWidget * widget );
+    static YCPValue tryGetItemSelectorSelectedItems     ( YWidget * widget );
     static YCPValue tryGetTableSelectedItems		( YWidget * widget );
     static YCPValue tryGetTreeSelectedItems		( YWidget * widget );
     static YCPValue tryGetMultiSelectionBoxCurrentItem	( YWidget * widget );
@@ -146,6 +152,7 @@ protected:
     static YCPValue tryGetTableItem			( YWidget * widget, const YCPTerm & propertyTerm );
     static YCPValue tryGetTableItems			( YWidget * widget );
     static YCPValue tryGetTreeItems			( YWidget * widget );
+    static YCPValue tryGetItemSelectorItems             ( YWidget * widget );
     static YCPValue tryGetMenuButtonItems		( YWidget * widget );
     static YCPValue tryGetSelectionWidgetItems		( YWidget * widget );
     static YCPValue tryGetBarGraphValues		( YWidget * widget );

--- a/src/YCP_UI.cc
+++ b/src/YCP_UI.cc
@@ -1,6 +1,7 @@
 /****************************************************************************
 
 Copyright (c) 2000 - 2010 Novell, Inc.
+Copyright (c) 2019 SUSE LLC
 All Rights Reserved.
 
 This program is free software; you can redistribute it and/or
@@ -108,8 +109,8 @@ YCPValue YCP_UI::HasSpecialWidget( const YCPSymbol & widget )
     else if ( symbol == YUISpecialWidget_PartitionSplitter	)	hasWidget = fact->hasPartitionSplitter();
     else if ( symbol == YUISpecialWidget_SimplePatchSelector	)	hasWidget = fact->hasSimplePatchSelector();
     else if ( symbol == YUISpecialWidget_Wizard			)	hasWidget = fact->hasWizard();
-    else if ( symbol == YUISpecialWidget_DateField)	hasWidget = fact->hasDateField();
-    else if ( symbol == YUISpecialWidget_TimeField)	hasWidget = fact->hasTimeField();
+    else if ( symbol == YUISpecialWidget_DateField              )	hasWidget = fact->hasDateField();
+    else if ( symbol == YUISpecialWidget_TimeField              )	hasWidget = fact->hasTimeField();
     else if ( symbol == YUISpecialWidget_TimezoneSelector	)	hasWidget = fact->hasTimezoneSelector();
     else if ( symbol == YUISpecialWidget_Graph			)	hasWidget = fact->hasGraph();
     else if ( symbol == YUISpecialWidget_ContextMenu		)	hasWidget = fact->hasContextMenu();


### PR DESCRIPTION
## Trello

https://trello.com/c/7qI1AAvN/1300-5-libyui-1-of-n-selection-widget-ysingleitemselector-ymultiitemselector

## Description

This adds the new `SingleItemSelector` and `MultiItemSelector` widgets to the UI interpreter.

**Notice** that this also needs the symbols to be exported to the yast-ruby-bindings.

## Related PR

https://github.com/yast/yast-ruby-bindings/pull/233

## Example Screenshots

### ItemSelector1

![ItemSelector1-01-ask-config](https://user-images.githubusercontent.com/11538225/65446277-4fccd380-de34-11e9-8d81-80b429f2c1f7.png)

![ItemSelector1-02-main](https://user-images.githubusercontent.com/11538225/65446640-1052b700-de35-11e9-9ad0-e0ab5e016e4d.png)

![ItemSelector1-03-result](https://user-images.githubusercontent.com/11538225/65446299-56f3e180-de34-11e9-93d9-edecbd68da3a.png)


### SingleItemSelector1

![SingleItemSelector1](https://user-images.githubusercontent.com/11538225/65446317-5f4c1c80-de34-11e9-9449-2b683e7ed042.png)

### MultiItemSelector1

![MultiItemSelector1](https://user-images.githubusercontent.com/11538225/65446334-683cee00-de34-11e9-853e-714237fa142e.png)
