### PR TITLE
require correct libyui version (bsc#1153103)

### DIFF
--- a/package/yast2-ycp-ui-bindings.changes
+++ b/package/yast2-ycp-ui-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Nov 12 09:27:46 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
+
+- require correct libyui version (bsc#1153103)
+- 4.2.5
+
+-------------------------------------------------------------------
 Thu Nov  7 13:26:47 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Support for CustomStatusItemSelector (bsc#1084674)

--- a/package/yast2-ycp-ui-bindings.spec
+++ b/package/yast2-ycp-ui-bindings.spec
@@ -15,6 +15,9 @@
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
 
+# YUIWidget_CustomStatusItemSelector
+%define min_yui_version	3.8.4
+%define yui_so		10
 
 Name:           yast2-ycp-ui-bindings
 Version:        4.2.4
@@ -38,8 +41,8 @@ BuildRequires:	sgml-skel
 Requires:	yast2-core
 BuildRequires:	yast2-core-devel
 
-# YUIWidget_CustomStatusItemSelector
-BuildRequires:	libyui-devel >= 3.8.4
+BuildRequires:	libyui-devel >= %min_yui_version
+Requires:	libyui%yui_so >= %min_yui_version
 
 # libyui ImplPtr
 BuildRequires:	boost-devel
@@ -60,7 +63,7 @@ Summary:	YaST2 - YCP Bindings for the YaST2 User Interface Engine
 Requires:	glibc-devel
 Requires:	libstdc++-devel
 Requires:	boost-devel
-Requires:	libyui-devel
+Requires:	libyui-devel >= %min_yui_version
 Requires:	yast2-core-devel
 Requires:	yast2-devtools
 


### PR DESCRIPTION
## Problem

After updating `yast-ycp-ui-bindings` yast crashes.

- https://bugzilla.suse.com/show_bug.cgi?id=1153103
- https://trello.com/c/59EhM1jw

This was caused by using an incompatible [libyui](https://github.com/libyui/libyui)

## Solution

Require minimally needed `libyui` version explicitly in  `yast-ycp-ui-bindings` package.