### PR TITLE
require correct libyui so version 11 (bsc#1132247)

### DIFF
--- a/package/yast2-ycp-ui-bindings.changes
+++ b/package/yast2-ycp-ui-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec 12 09:45:27 CET 2019 - aschnell@suse.com
+
+- require correct libyui so version 11 (bsc#1132247)
+- 4.2.6
+
+-------------------------------------------------------------------
 Tue Nov 12 09:27:46 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
 
 - require correct libyui version (bsc#1153103)

--- a/package/yast2-ycp-ui-bindings.spec
+++ b/package/yast2-ycp-ui-bindings.spec
@@ -17,10 +17,10 @@
 
 # YUIWidget_CustomStatusItemSelector
 %define min_yui_version	3.8.4
-%define yui_so		10
+%define yui_so		11
 
 Name:           yast2-ycp-ui-bindings
-Version:        4.2.4
+Version:        4.2.6
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
libyui has so version 11 now. Without the change here still so version 10 is required.