### PR TITLE
[SLE-9109] Packages online search

### DIFF
--- a/package/yast2-ycp-ui-bindings.changes
+++ b/package/yast2-ycp-ui-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 23 16:47:02 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add support for the option to enable the online search
+  feature in the package selector (jsc#SLE-9109).
+- 4.2.9
+
+-------------------------------------------------------------------
 Thu Jan 23 12:03:31 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Allow integer as initial item status (part of bsc#1084674)

--- a/package/yast2-ycp-ui-bindings.spec
+++ b/package/yast2-ycp-ui-bindings.spec
@@ -20,7 +20,7 @@
 %define yui_so		11
 
 Name:           yast2-ycp-ui-bindings
-Version:        4.2.8
+Version:        4.2.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/YCPDialogParser.cc
+++ b/src/YCPDialogParser.cc
@@ -2867,6 +2867,7 @@ YCPDialogParser::parsePackageSelector( YWidget * parent, YWidgetOpt & opt,
 	    else if ( sym == YUIOpt_testMode		)	modeFlags |= YPkg_TestMode;
 	    else if ( sym == YUIOpt_repoMgr		)	modeFlags |= YPkg_RepoMgr;
 	    else if ( sym == YUIOpt_confirmUnsupported	)	modeFlags |= YPkg_ConfirmUnsupported;
+	    else if ( sym == YUIOpt_onlineSearch	)	modeFlags |= YPkg_OnlineSearch;
 	    else logUnknownOption( term, optList->value(o) );
 	}
 	else logUnknownOption( term, optList->value(o) );


### PR DESCRIPTION
Please, see the whole picture in yast/yast-registration#467.

This PR adds support for an option to enable the online search in the package selector.