### PR TITLE
Allow Integer as Initial Item Status

### DIFF
--- a/package/yast2-ycp-ui-bindings.changes
+++ b/package/yast2-ycp-ui-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 23 12:03:31 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Allow integer as initial item status (part of bsc#1084674)
+- 4.2.8
+
+-------------------------------------------------------------------
 Wed Dec 18 14:56:39 CET 2019 - aschnell@suse.com
 
 - handle sort key in parser for table item (bsc#1140018)

--- a/package/yast2-ycp-ui-bindings.spec
+++ b/package/yast2-ycp-ui-bindings.spec
@@ -20,7 +20,7 @@
 %define yui_so		11
 
 Name:           yast2-ycp-ui-bindings
-Version:        4.2.7
+Version:        4.2.8
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
When creating a item for a CustomStatusItemSelector, you can now also specify an integer as the initial status, not only (as before) a boolean.