### PR TITLE
Auto-wrapping for YLabel Widgets (UI Interpreter Part)

### DIFF
--- a/examples/Label-AutoWrap1.rb
+++ b/examples/Label-AutoWrap1.rb
@@ -1,0 +1,28 @@
+# encoding: utf-8
+
+module Yast
+  class LabelAutoWrap1Client < Client
+    def main
+      Yast.import "UI"
+
+      width = 40
+      text  = "This is an example of a lengthy text that needs to be auto-wrapped to make it fit. "
+      text += "And it goes on and on and on; it does not have any newline. "
+      text += "It's just one single very long line. "
+      text += "The widget has to find appropriate places to break that long text into lines."
+
+      UI.OpenDialog(
+        VBox(
+          MinWidth( width, Label(Opt(:autoWrap), text) ),
+          PushButton("&OK")
+        )
+      )
+      UI.UserInput
+      UI.CloseDialog
+
+      nil
+    end
+  end
+end
+
+Yast::LabelAutoWrap1Client.new.main

--- a/package/yast2-ycp-ui-bindings.changes
+++ b/package/yast2-ycp-ui-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun  4 11:52:17 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Added widget option autoWrap for label widget (bsc#1172513) 
+- Require libyui.so.12
+- 4.2.10
+
+-------------------------------------------------------------------
 Thu Jan 23 16:47:02 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add support for the option to enable the online search

--- a/package/yast2-ycp-ui-bindings.changes
+++ b/package/yast2-ycp-ui-bindings.changes
@@ -3,7 +3,7 @@ Thu Jun  4 11:52:17 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Added widget option autoWrap for label widget (bsc#1172513) 
 - Require libyui.so.12
-- 4.2.10
+- 4.3.10
 
 -------------------------------------------------------------------
 Thu Jan 23 16:47:02 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>

--- a/package/yast2-ycp-ui-bindings.spec
+++ b/package/yast2-ycp-ui-bindings.spec
@@ -16,11 +16,11 @@
 #
 
 # YUIWidget_CustomStatusItemSelector
-%define min_yui_version	3.9.1
-%define yui_so		11
+%define min_yui_version	3.10.0
+%define yui_so		12
 
 Name:           yast2-ycp-ui-bindings
-Version:        4.2.9
+Version:        4.2.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-ycp-ui-bindings.spec
+++ b/package/yast2-ycp-ui-bindings.spec
@@ -20,7 +20,7 @@
 %define yui_so		12
 
 Name:           yast2-ycp-ui-bindings
-Version:        4.2.10
+Version:        4.3.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/YCPDialogParser.cc
+++ b/src/YCPDialogParser.cc
@@ -1196,6 +1196,7 @@ bool YCPDialogParser::startsWith( const string & str, const char * word )
  * @class	YLabel
  * @arg		string label
  * @option	outputField make the label look like an input field in read-only mode
+ * @option	autoWrap automatic word wrapping (use with caution!)
  * @option	boldFont use a bold font
  *
  * @example	Label1.rb
@@ -1211,6 +1212,16 @@ bool YCPDialogParser::startsWith( const string & str, const char * word )
  * A <tt>Label</tt> is static text displayed in the dialog.
  * A <tt>Heading</tt> is static text with a bold and/or larger font.
  * In both cases, the text may contain newlines.
+ *
+ * The <tt>autoWrap</tt> option makes the label wrap words automatically: Any
+ * whitespace between words is normalized to a single blank, and then newlines
+ * are added as needed to make it fit into its assigned width. The height
+ * changes accordingly. An auto-wrap label does not have a reasonable preferred
+ * width, so it is strongly advised to put it into a MinWidth container widget
+ * or otherwise enforce a reasonable width from the outside. A dialog with many
+ * auto-wrapping labels might have trouble finding a reasonable geometry to
+ * accomodate all widgets, so use this option sparingly. In particular, do not
+ * simply add this option to all labels; this is bound to fail.
  **/
 
 YWidget *
@@ -1228,10 +1239,12 @@ YCPDialogParser::parseLabel( YWidget * parent, YWidgetOpt & opt,
     // Parse options
 
     bool isOutputField = false;
+    bool autoWrap      = false;
 
     for ( int o=0; o < optList->size(); o++ )
     {
-	if ( optList->value(o)->isSymbol() && optList->value(o)->asSymbol()->symbol() == YUIOpt_outputField ) isOutputField = true;
+	if      ( optList->value(o)->isSymbol() && optList->value(o)->asSymbol()->symbol() == YUIOpt_outputField ) isOutputField = true;
+	else if ( optList->value(o)->isSymbol() && optList->value(o)->asSymbol()->symbol() == YUIOpt_autoWrap    ) autoWrap      = true;
 	else logUnknownOption( term, optList->value(o) );
     }
 
@@ -1244,6 +1257,9 @@ YCPDialogParser::parseLabel( YWidget * parent, YWidgetOpt & opt,
 
     if ( opt.boldFont.value() )
 	label->setUseBoldFont();
+
+    if ( autoWrap )
+        label->setAutoWrap();
 
     return label;
 }


### PR DESCRIPTION
## Trello

https://trello.com/c/AAaxH5Cg/

**This is the UI interpreter part for autoWrap Label widgets.**

## Bugzilla

https://bugzilla.opensuse.org/show_bug.cgi?id=1172513


## Screenshots

The new _Label-Autowrap1.rb_ example from this PR:

![Label-AutoWrap1-qt](https://user-images.githubusercontent.com/11538225/83743005-67628a00-a65a-11ea-8bc8-e7e40ea7bdb3.png)

![Label-AutoWrap1-ncurses](https://user-images.githubusercontent.com/11538225/83743019-6c273e00-a65a-11ea-89eb-9181d3067955.png)



## Travis Build Failure

This depends on some new methods in libyui which are not yet available for the Travis docker image.