### PR TITLE
New Widget: MenuBar

### DIFF
--- a/examples/MenuBar1.rb
+++ b/examples/MenuBar1.rb
@@ -16,7 +16,7 @@ module Yast
     def dialog_widgets
       MinSize( 50, 20,
         VBox(
-          term(:MenuBar, Id(:menu_bar), main_menus),
+          MenuBar(Id(:menu_bar), main_menus),
           HVCenter(
             HVSquash(
               VBox(
@@ -37,11 +37,11 @@ module Yast
 
     def main_menus
       [
-        term(:menu, "&File", file_menu),
-        term(:menu, "&Edit", edit_menu),
-        term(:menu, "&View", view_menu),
-        term(:menu, "&Options", options_menu),
-        term(:menu, "&Debug", debug_menu)
+        Menu("&File", file_menu),
+        Menu("&Edit", edit_menu),
+        Menu("&View", view_menu),
+        Menu("&Options", options_menu),
+        Menu("&Debug", debug_menu)
       ].freeze
     end
 

--- a/package/yast2-ycp-ui-bindings.changes
+++ b/package/yast2-ycp-ui-bindings.changes
@@ -1,16 +1,22 @@
 -------------------------------------------------------------------
+Wed Aug 12 12:12:01 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Use new syntax (MenuBar(), Menu()) in MenuBar example (bsc#1175115)
+- 4.3.2
+
+-------------------------------------------------------------------
 Tue Aug 11 15:10:00 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Added MenuBar widget (bsc#1175115)
 - Require libyui.so.13
-- 4.3.11
+- 4.3.1
 
 -------------------------------------------------------------------
 Thu Jun  4 11:52:17 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Added widget option autoWrap for label widget (bsc#1172513) 
 - Require libyui.so.12
-- 4.3.10
+- 4.3.0
 
 -------------------------------------------------------------------
 Thu Jan 23 16:47:02 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>

--- a/package/yast2-ycp-ui-bindings.spec
+++ b/package/yast2-ycp-ui-bindings.spec
@@ -20,7 +20,7 @@
 %define yui_so		13
 
 Name:           yast2-ycp-ui-bindings
-Version:        4.3.1
+Version:        4.3.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
## Trello

https://trello.com/c/4GtDpmMo/1956-5-menu-bar-widget

## Overview

This uses the new syntax in the MenuBar example:

```Ruby
MenuBar(...)
```

instead of 

```Ruby
term(:MenuBar, ...)
```