### PR TITLE
Support for OpenItems Property for the Table Widget

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 script:
   # the "yast-travis-cpp" script is included in the base yastdevel/cpp image
   # see https://github.com/yast/docker-yast-cpp/blob/master/yast-travis-cpp
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-ycp-ui-bindings-image yast-travis-cpp
+  - docker run -it -e TRAVIS=1 --privileged -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-ycp-ui-bindings-image yast-travis-cpp
 
 after_success:
   - ./.surge.sh

--- a/examples/Image1.rb
+++ b/examples/Image1.rb
@@ -10,21 +10,13 @@ module Yast
         VBox(
           Image(
             Id("image"),
-            "/usr/share/YaST2/theme/current/wallpapers/welcome.jpg",
+            "/usr/share/grub2/themes/openSUSE/logo.png",
             "fallback text"
           ),
           PushButton(Opt(:default), "&OK")
         )
       )
       UI.UserInput
-      if UI.WidgetExists(Id("image"))
-        UI.ChangeWidget(Id("image"), :Enabled, false)
-        UI.UserInput
-        UI.ChangeWidget(Id("image"), :Enabled, true)
-        UI.UserInput
-      else
-        Builtins.y2error("No such widget id")
-      end
       UI.CloseDialog
 
       nil

--- a/examples/Table-nested-items.rb
+++ b/examples/Table-nested-items.rb
@@ -5,10 +5,12 @@
 module Yast
   class TableNestedItems < Client
     Yast.import "UI"
+    include Yast::Logger
 
     def main
       UI.OpenDialog(main_dialog)
       update_selected(current_table_item)
+      update_open_items(open_items)
       handle_events
       UI.CloseDialog
     end
@@ -27,6 +29,8 @@ module Yast
             VSpacing(0.2),
             Left(Label("Selected:")),
             Label(Id(:selected), Opt(:outputField, :hstretch), "..."),
+            Left(Label("Open Items:")),
+            Label(Id(:open_items), Opt(:outputField, :hstretch), "..."),
             VSpacing(0.3),
             Right(
               PushButton(Id(:close), "&Close")
@@ -87,6 +91,7 @@ module Yast
           break # leave event loop
         when :table
           update_selected(current_table_item)
+          update_open_items(open_items)
         end
         id
       end
@@ -99,6 +104,15 @@ module Yast
     def update_selected(id)
       id ||= "<nil>"
       UI.ChangeWidget(Id(:selected), :Value, id.to_s)
+    end
+
+    def open_items
+      UI.QueryWidget(Id(:table), :OpenItems).keys
+    end
+
+    def update_open_items(ids)
+      ids ||= "<nil>"
+      UI.ChangeWidget(Id(:open_items), :Value, ids.to_s)
     end
   end
 end

--- a/examples/Table-nested-items.rb
+++ b/examples/Table-nested-items.rb
@@ -27,10 +27,16 @@ module Yast
             VSpacing(0.2),
             table,
             VSpacing(0.2),
-            Left(Label("Selected:")),
-            Label(Id(:selected), Opt(:outputField, :hstretch), "..."),
-            Left(Label("Open Items:")),
-            Label(Id(:open_items), Opt(:outputField, :hstretch), "..."),
+            HBox(
+              # Putting both in one line to enable grepping for NCurses UI tests
+              HSquash(MinWidth(12, Label("Selected: "))),
+              Label(Id(:selected), Opt(:outputField, :hstretch), "...")
+            ),
+            HBox(
+              # Putting both in one line to enable grepping for NCurses UI tests
+              HSquash(MinWidth(12, Label("Open Items: "))),
+              Label(Id(:open_items), Opt(:outputField, :hstretch), "...")
+            ),
             VSpacing(0.3),
             Right(
               PushButton(Id(:close), "&Close")

--- a/examples/Table-nested-items.rb
+++ b/examples/Table-nested-items.rb
@@ -117,8 +117,7 @@ module Yast
     end
 
     def update_open_items(ids)
-      ids ||= "<nil>"
-      UI.ChangeWidget(Id(:open_items), :Value, ids.to_s)
+      UI.ChangeWidget(Id(:open_items), :Value, ids.inspect)
     end
   end
 end

--- a/package/yast2-ycp-ui-bindings.changes
+++ b/package/yast2-ycp-ui-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct 15 13:45:24 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Added support for OpenItems property for (nested) tables (bsc#1176402)
+- 4.3.4
+
+-------------------------------------------------------------------
 Fri Oct  9 12:04:21 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Added Nested Tables (bsc#1176402)

--- a/package/yast2-ycp-ui-bindings.spec
+++ b/package/yast2-ycp-ui-bindings.spec
@@ -20,7 +20,7 @@
 %define yui_so		14
 
 Name:           yast2-ycp-ui-bindings
-Version:        4.3.3
+Version:        4.3.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/YCPPropertyHandler.cc
+++ b/src/YCPPropertyHandler.cc
@@ -1,7 +1,7 @@
 /****************************************************************************
 
 Copyright (c) 2000 - 2010 Novell, Inc.
-Copyright (c) 2019 SUSE LLC
+Copyright (c) 2019 - 2020 SUSE LLC
 All Rights Reserved.
 
 This program is free software; you can redistribute it and/or
@@ -220,7 +220,7 @@ YCPPropertyHandler::getComplexProperty( YWidget * widget, const string & propert
     }
     else if ( propertyName == YUIProperty_OpenItems )
     {
-	val = tryGetTreeOpenItems	( widget );	if ( ! val.isNull() ) return val;
+	val = tryGetOpenItems           ( widget );	if ( ! val.isNull() ) return val;
     }
     else if ( propertyName == YUIProperty_CurrentBranch )
     {
@@ -1261,24 +1261,24 @@ YCPPropertyHandler::tryGetWizardCurrentItem( YWidget * widget )
 
 
 YCPValue
-YCPPropertyHandler::tryGetTreeOpenItems( YWidget * widget )
+YCPPropertyHandler::tryGetOpenItems( YWidget * widget )
 {
-    YTree * tree = dynamic_cast<YTree *> (widget);
+    YSelectionWidget * selWidget = dynamic_cast<YSelectionWidget *> (widget);
 
-    if ( ! tree )
+    if ( ! selWidget )
 	return YCPNull();
 
     YCPMap openItems;
-    getTreeOpenItems( openItems, tree->itemsBegin(), tree->itemsEnd() );
+    getOpenItems( openItems, selWidget->itemsBegin(), selWidget->itemsEnd() );
 
     return openItems;
 }
 
 
 void
-YCPPropertyHandler::getTreeOpenItems( YCPMap &			openItems,
-				      YItemConstIterator	begin,
-				      YItemConstIterator	end )
+YCPPropertyHandler::getOpenItems( YCPMap &              openItems,
+                                  YItemConstIterator	begin,
+                                  YItemConstIterator	end )
 {
     for ( YItemConstIterator it = begin; it != end; ++it )
     {
@@ -1286,18 +1286,35 @@ YCPPropertyHandler::getTreeOpenItems( YCPMap &			openItems,
 
 	if ( item )
 	{
-	    YCPTreeItem * ycpTreeItem = dynamic_cast<YCPTreeItem *> (item);
+            YTreeItem * yTreeItem = dynamic_cast<YTreeItem *> (item);
 
-	    if ( item->isOpen() )
+	    if ( yTreeItem->isOpen() )
 	    {
-		if ( ycpTreeItem && ycpTreeItem->hasId() )
-		    openItems.add( ycpTreeItem->id(), YCPString( "ID" ) );
-		else
-		    openItems.add( YCPString( item->label() ), YCPString( "Text" ) );
+                YCPTableItem * ycpTableItem = dynamic_cast<YCPTableItem *> (item);
+
+                if ( ycpTableItem )
+                {
+                    if ( ycpTableItem->hasId() )
+                        openItems.add( ycpTableItem->id(), YCPString( "ID" ) );
+                    else
+                        openItems.add( ycpTableItem->label( 0 ), YCPString( "Text" ) );
+                }
+                else
+                {
+                    YCPTreeItem * ycpTreeItem  = dynamic_cast<YCPTreeItem *> (item);
+
+                    if ( ycpTreeItem )
+                    {
+                        if ( ycpTreeItem->hasId() )
+                            openItems.add( ycpTreeItem->id(), YCPString( "ID" ) );
+                        else
+                            openItems.add( ycpTreeItem->label(), YCPString( "Text" ) );
+                    }
+                }
 	    }
 
 	    if ( item->hasChildren() )
-		getTreeOpenItems( openItems, item->childrenBegin(), item->childrenEnd() );
+		getOpenItems( openItems, item->childrenBegin(), item->childrenEnd() );
 	}
     }
 }

--- a/src/YCPPropertyHandler.h
+++ b/src/YCPPropertyHandler.h
@@ -1,7 +1,7 @@
 /****************************************************************************
 
 Copyright (c) 2000 - 2010 Novell, Inc.
-Copyright (c) 2019 SUSE LLC
+Copyright (c) 2019 - 2020  SUSE LLC
 All Rights Reserved.
 
 This program is free software; you can redistribute it and/or
@@ -148,7 +148,7 @@ protected:
     static YCPValue tryGetTableSelectedItems		( YWidget * widget );
     static YCPValue tryGetTreeSelectedItems		( YWidget * widget );
     static YCPValue tryGetMultiSelectionBoxCurrentItem	( YWidget * widget );
-    static YCPValue tryGetTreeOpenItems			( YWidget * widget );
+    static YCPValue tryGetOpenItems			( YWidget * widget );
     static YCPValue tryGetTreeCurrentBranch		( YWidget * widget );
     static YCPValue tryGetWizardCurrentItem		( YWidget * widget );
     static YCPValue tryGetTableCell			( YWidget * widget, const YCPTerm & propertyTerm );
@@ -180,12 +180,12 @@ protected:
 				  const YCPValue &	newEnabled );
 
     /**
-     * Helper function for tryGetTreeOpenItems(): Get any open tree items
+     * Helper function for tryGetOpenItems(): Get any open tree items
      * between iterators 'begin' and 'end' and add them to the 'openItems' map.
      **/
-    static void getTreeOpenItems( YCPMap &		openItems,
-				  YItemConstIterator	begin,
-				  YItemConstIterator	end );
+    static void getOpenItems( YCPMap &                  openItems,
+                              YItemConstIterator	begin,
+                              YItemConstIterator	end );
 
     /**
      * Helper function for tryGetMenuWidgetEnabledItems(): Get the enabled /

--- a/src/YCP_UI.cc
+++ b/src/YCP_UI.cc
@@ -681,16 +681,16 @@ YCPValue YCP_UI::ChangeWidget( const YCPValue & idValue, const YCPValue & proper
 						idValue->toString().c_str() ) );
 	}
 
-	YCPValue	id	= YCPDialogParser::parseIdTerm( idValue );
-	YWidget *	widget 	= YCPDialogParser::findWidgetWithId( id,
-								     true ); // throw if not found
+	YCPValue   id	  = YCPDialogParser::parseIdTerm( idValue );
+	YWidget *  widget = YCPDialogParser::findWidgetWithId( id,
+                                                               true ); // throw if not found
 
 	YPropertySet propSet = widget->propertySet();
 
 	if ( property->isSymbol() )
 	{
 	    string oldShortcutString = widget->shortcutString();
-	    string propertyName	 = property->asSymbol()->symbol();
+	    string propertyName	     = property->asSymbol()->symbol();
 
 	    YPropertyValue val;
 
@@ -715,8 +715,8 @@ YCPValue YCP_UI::ChangeWidget( const YCPValue & idValue, const YCPValue & proper
 	}
 	else if ( property->isTerm() )
 	{
-	    bool success	= YCPPropertyHandler::setComplexProperty( widget, property->asTerm(), newValue );
-	    ret		= YCPBoolean( success );
+	    bool success = YCPPropertyHandler::setComplexProperty( widget, property->asTerm(), newValue );
+	    ret	 = YCPBoolean( success );
 	}
 	else
 	{


### PR DESCRIPTION
## Trello

https://trello.com/c/g0CpGq6T/1915-3-partitioner-nested-tables

## Problem

We want to be able to save and restore the previous status of open and closed branches when switching to other views in the partitioner and back.

## Solution

This implements the special handling for the `OpenItems` property for all YSelectionWidgets that use one of YCPTreeItem or YCPTableItem.

Inheritance hierarchy:

- YCPTableItem < YTableItem < YTreeItem < YItem
- YCPTreeItem < YTreeItem < YItem

YTreeItem adds the `isOpen()` and `setOpen()` methods. the YCP*Item classes add a YCPValue ID that is commonly used in Ruby application code (usually a Ruby symbol / YCPSymbol or a YCPString, but it could also be other basic types).

## Spec File Requires?

We don't need to require any specific version of the other two packages (see below). It works best with the latest versions, of course, but there is no hard requirement. This change can live on its own just fine.

## Related PRs

- libyui: https://github.com/libyui/libyui/pull/174
- Qt UI: https://github.com/libyui/libyui-qt/pull/138
- NCurses UI: Not necessary, works out of the box
