### PR TITLE
Added missing Bugzilla number

### DIFF
--- a/package/yast2-ycp-ui-bindings.changes
+++ b/package/yast2-ycp-ui-bindings.changes
@@ -2,6 +2,7 @@
 Wed Oct 28 16:52:12 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Added example for more in-depth MultiSelectionBox testing
+  (bsc#1177982, bsc#1177985)
 - 4.3.5
 
 -------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to https://github.com/yast/yast-ycp-ui-bindings/pull/58 :

IBS was complaining about a missing Bugzilla number in the change log, so I added it.