### PR TITLE
Extended MenuBar-shortcut-test UI Example

### DIFF
--- a/examples/MenuBar-shortcuts-test.rb
+++ b/examples/MenuBar-shortcuts-test.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
 
+# Example for a menu bar and its shortcuts vs. button shortcuts
+#
+# This is also used in the NCurses UI test suite.
+# When changing this example, make sure that test suite does not fail!
+
 module Yast
   class MenuBarShortcutsClient < Client
     Yast.import "UI"
@@ -22,21 +27,21 @@ module Yast
               HVSquash(
                 VBox(
                   ReplacePoint(Id(:rp_extra_buttons), Empty()),
-                  VSpacing( 0.2 ),
+                  VSpacing( 1 ),
                   Left(CheckBox(Id(:cb_extra_buttons), Opt(:notify), "Extra &Buttons", false)),
                   VSpacing( 1 ),
-                  Left(Label("Last Event:")),
-                  VSpacing( 0.2 ),
-                  MinWidth( 20,
-                    Label(Id(:last_event), Opt(:outputField), "<none>")
-                  ),
-                  VSpacing( 2 ),
-                  Left(CheckBox(Id(:read_only), Opt(:notify), "Read &Only", true))
+                  Left(CheckBox(Id(:read_only), Opt(:notify), "Read &Only", true)),
+                  VSpacing( 3 ),
+                  HBox(
+                    # Putting both in one line to enable grepping for NCurses UI tests
+                    HSquash(Label("Last Event: ")),
+                    MinWidth(20, Label(Id(:last_event), Opt(:outputField, :hstretch), "<none>"))
+                  )
                 )
               )
             )
           ),
-          Right(PushButton(Id(:cancel), "&Quit"))
+          Right(PushButton(Id(:quit), "&Quit"))
         )
       )
     end
@@ -57,7 +62,7 @@ module Yast
         Item(Id(:save), "&Save"),
         Item(Id(:save_as), "Save &As..."),
         Item("---"),
-        Item(Id(:quit), "&Quit"),
+        Item(Id(:quit), "&Quit")
       ].freeze
     end
 
@@ -75,7 +80,7 @@ module Yast
         Item(Id(:view_compact), "&Compact"),
         Item(Id(:view_detailed), "&Detailed"),
         Item("---"),
-        term(:menu, "&Zoom", zoom_menu),
+        term(:menu, "&Zoom", zoom_menu)
       ].freeze
     end
 
@@ -83,13 +88,13 @@ module Yast
       [
         Item(Id(:zoom_in), "Zoom &In" ),
         Item(Id(:zoom_out), "Zoom &Out" ),
-        Item(Id(:zoom_default), "Zoom &Default" ),
+        Item(Id(:zoom_default), "Zoom &Default" )
       ].freeze
     end
 
     def options_menu
       [
-        Item(Id(:settings), "&Settings..."),
+        Item(Id(:settings), "&Settings...")
       ].freeze
     end
 
@@ -127,11 +132,11 @@ module Yast
       # so their shortcuts get priority over menus / menu items
       HSquash(
         HBox(Id(:extra_button_box),
-          PushButton("&Fi"),
-          PushButton("&Ed"),
-          PushButton("&Vi"),
-          PushButton("&Opt"),
-          PushButton("&Cp")
+          PushButton(Id(:b_file), "&File"),
+          PushButton(Id(:b_edit), "&Edit"),
+          PushButton(Id(:b_view), "&View"),
+          PushButton(Id(:b_opt), "&Opt"),
+          PushButton(Id(:b_cp), "&Cp")
         )
       )
     end
@@ -156,6 +161,9 @@ module Yast
 
     def show_event(id)
       UI.ChangeWidget(:last_event, :Value, id.to_s)
+      # Changing the content of a label does not trigger a re-layout by default;
+      # we need to do that manually
+      UI.RecalcLayout
     end
 
     # Enable or disable menu items depending on the current content of the

--- a/package/yast2-ycp-ui-bindings.changes
+++ b/package/yast2-ycp-ui-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Nov 16 16:19:49 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Extended MenuBar-shortcut-test example to test shortcut priority
+  (bsc#1175489)
+- 4.3.7
+
+-------------------------------------------------------------------
 Tue Nov  3 12:30:19 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Added test case for boo#1178394

--- a/package/yast2-ycp-ui-bindings.spec
+++ b/package/yast2-ycp-ui-bindings.spec
@@ -20,7 +20,7 @@
 %define yui_so		14
 
 Name:           yast2-ycp-ui-bindings
-Version:        4.3.6
+Version:        4.3.7
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
## Trello

https://trello.com/c/JfDqTpdi/2150-3-menu-bar-refinements


## Changes

This extends the MenuBar-shortcut-test UI example to support testing the keyboad shortcut priorities of toplevel menus vs. buttons (see https://github.com/libyui/libyui/pull/175).


## Screenshots

![MenuBar-shortcuts-test-no-extra-buttons-ncurses](https://user-images.githubusercontent.com/11538225/99280251-6f416f80-2831-11eb-9c4c-a2af358ab54a.png)

![MenuBar-shortcuts-test-extra-buttons-ncurses](https://user-images.githubusercontent.com/11538225/99280277-74062380-2831-11eb-9be7-aefe32fd39b6.png)

## Usage in Tests

Notice that toplevel menus like "File", "Edit", "View" are competing for the exact same keyboard shortcuts as the extra buttons that appear when the corresponding combo box is toggled.

We set up priorities for them so the toplevel menus win, and the buttons are assigned different shortcuts.


## Related PRs

- Master PR with the feature: https://github.com/libyui/libyui/pull/175
- New unit test: https://github.com/yast/yast-ruby-bindings/pull/262