### PR TITLE
New UI Example for ComboBox

### DIFF
--- a/examples/ComboBox-test.rb
+++ b/examples/ComboBox-test.rb
@@ -1,0 +1,126 @@
+# encoding: utf-8
+
+# Example for combo box
+#
+# This is also used in the NCurses UI test suite.
+# When changing this example, make sure that test suite does not fail!
+
+module Yast
+  class ComboBoxItemIds < Client
+    Yast.import "UI"
+    include Yast::Logger
+
+    def main
+      UI.OpenDialog(main_dialog)
+      update_output_fields
+      handle_events
+      UI.CloseDialog
+    end
+
+    def main_dialog
+      MinSize(
+        50, 12,
+        MarginBox(
+          1, 0.4,
+          VBox(
+            Left(
+              Heading("Pizza Selector")
+            ),
+            VSpacing(0.2),
+            HCenter(
+              HSquash(
+                MinWidth(30, pizza_combo_box)
+              )
+            ),
+            VSpacing(1),
+            pizza_buttons,
+            VSpacing(1),
+            output_fields,
+            VSpacing(0.3),
+            VStretch(),
+            Right(
+              PushButton(Id(:close), "&Close")
+            )
+          )
+        )
+      )
+    end
+
+    def pizza_combo_box
+      ComboBox(
+        Id(:cb_pizza),
+        Opt(:notify, :editable),
+        "Pizza:",
+        pizza_items
+      )
+    end
+
+    def pizza_items
+      [
+        Item(Id(:margherita), "Margherita"),
+        Item(Id(:salami), "Salami"),
+        Item(Id(:prosciutto), "Prosciutto"),
+        Item(Id(:quattro), "Quattro Stagioni"),
+        Item(Id(:speciale), "Speciale"),
+        Item(Id(:casa), "Della Casa")
+      ]
+    end
+
+    def pizza_buttons
+      HBox(
+        PushButton(Id(:speciale), "&Speciale"),
+        PushButton(Id(:casa), "Della C&asa"),
+        PushButton(Id(:salami), "&Daily Special"),
+        PushButton(Id(:custom), "C&ustom")
+      )
+    end
+
+    def output_fields
+      VBox(
+        HBox(
+          # Putting both in one line to enable grepping for NCurses UI tests
+          Label("Selected: "),
+          Label(Id(:selected_pizza), Opt(:outputField, :hstretch), "...")
+        )
+      )
+    end
+
+    def handle_events
+      while true
+        id = UI.UserInput
+        case id
+
+        when :close, :cancel # :cancel is WM_CLOSE
+          break # leave event loop
+        when :cb_pizza
+          update_output_fields
+        when :speciale, :casa, :salami
+          select_pizza(id)
+          update_output_fields
+        when :custom
+          select_pizza("Pizza with ham and onions")
+          update_output_fields
+        end
+        id
+      end
+    end
+
+    def cb_value
+      UI.QueryWidget(Id(:cb_pizza), :Value)
+    end
+
+    def select_pizza(pizza)
+      UI.ChangeWidget(Id(:cb_pizza), :Value, pizza)
+    end
+
+    def update_selected_pizza(value)
+      UI.ChangeWidget(Id(:selected_pizza), :Value, value.inspect)
+    end
+
+    def update_output_fields
+      update_selected_pizza(cb_value)
+    end
+  end
+end
+
+Yast::ComboBoxItemIds.new.main


### PR DESCRIPTION
This is an example to showcase how item IDs vs. item labels (text) work for a ComboBox widget.
It can also be used to test the ComboBox in general.

![ComboBox-test-1-qt](https://user-images.githubusercontent.com/11538225/99685040-6e534c80-2a82-11eb-91dd-e063fc134b1d.png)

![ComboBox-test-2-qt](https://user-images.githubusercontent.com/11538225/99685051-71e6d380-2a82-11eb-8407-1f394d7fdfcc.png)

![ComboBox-test-3-ncurses](https://user-images.githubusercontent.com/11538225/99685062-74492d80-2a82-11eb-953e-cf1bf26798bd.png)

-------------

No version bump and change log for this one; it can wait for the next submission of the package.