### PR TITLE
Added new UI built-in UI.AskForWidgetStyle ()

### DIFF
--- a/examples/FileSelection.rb
+++ b/examples/FileSelection.rb
@@ -17,7 +17,8 @@ module Yast
               VBox(
                 PushButton(Id(:askDir), Opt(:hstretch), "Select &Directory..."),
                 PushButton(Id(:load), Opt(:hstretch), "&Load File..."),
-                PushButton(Id(:saveAs), Opt(:hstretch), "Save &As...")
+                PushButton(Id(:saveAs), Opt(:hstretch), "Save &As..."),
+                PushButton(Id(:style), Opt(:hstretch), "&Widget Style...")
               )
             ),
             HSpacing(2)
@@ -48,6 +49,8 @@ module Yast
           )
         elsif @button == :saveAs
           @name = UI.AskForSaveFileName("/tmp", "*", "Save as...")
+        elsif @button == :style
+          UI.AskForWidgetStyle()
         end
 
         @name = "<canceled>" if @name == nil

--- a/package/yast2-ycp-ui-bindings.changes
+++ b/package/yast2-ycp-ui-bindings.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Feb  1 15:38:55 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Added UI.AskForWidgetStyle() (jsc#SLE-20564)
+- Added HasWidgetStyleSupport capability to UI.GetDisplayInfo()
+- Adapted to libyui SO bump 15 -> 16
+- 4.4.1
+
+-------------------------------------------------------------------
 Tue Apr 20 13:51:55 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - 4.4.0 (bsc#1185510)

--- a/package/yast2-ycp-ui-bindings.spec
+++ b/package/yast2-ycp-ui-bindings.spec
@@ -15,11 +15,12 @@
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
 
-%define min_yui_version	4.0.1
-%define yui_so		15
+# YApplication::askForWidgetStyle()
+%define min_yui_version	4.3.0
+%define yui_so		16
 
 Name:           yast2-ycp-ui-bindings
-Version:        4.4.0
+Version:        4.4.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/YCP_UI.cc
+++ b/src/YCP_UI.cc
@@ -516,7 +516,7 @@ YCPValue YCP_UI::doUserInput( const char * 	builtin_name,
  * For UIs that don't support this kind of specialized dialog, this is
  * equivalent to <tt>`mainDialog</tt> -- see also the
  * <tt>HasWizardDialogSupport</tt> entry of the map returned by
- * <tt>UI::GetDisplayInfo()</tt>. 
+ * <tt>UI::GetDisplayInfo()</tt>.
  *
  * The <tt>`warncolor</tt> option displays the entire dialog in a bright
  * warning color.
@@ -572,7 +572,7 @@ YCPBoolean YCP_UI::OpenDialog( const YCPTerm & opts, const YCPTerm & dialogTerm 
     {
 	if ( dialogType == YWizardDialog && ! YUI::yApp()->hasWizardDialogSupport() )
 	    dialogType = YMainDialog;
-	
+
 	YDialog * dialog = YUI::widgetFactory()->createDialog( dialogType, colorMode );
 	YUI_CHECK_NEW( dialog );
 
@@ -953,7 +953,7 @@ YCPBoolean YCP_UI::SetFocus( const YCPValue & idValue )
 	return YCPNull();
 
     YCPBoolean result = YCPNull();
-    
+
     try
     {
 	YCPValue id = YCPDialogParser::parseIdTerm( idValue );
@@ -1107,7 +1107,7 @@ void YCP_UI::DumpWidgetTree()
     // After all, this is a debugging function
     YDialog *currentDialog = YDialog::currentDialog(false);
 
-    if (currentDialog) 
+    if (currentDialog)
         currentDialog->dumpDialogWidgetTree();
     else
 	yuiWarning() << "No dialog exists :( Nothing to dump." << endl;
@@ -1253,8 +1253,9 @@ YCPMap YCP_UI::GetDisplayInfo()
     info_map->add( YCPString( YUICap_HasIconSupport		), YCPBoolean( app->hasIconSupport()	) );
     info_map->add( YCPString( YUICap_HasAnimationSupport	), YCPBoolean( app->hasAnimationSupport()   ) );
     info_map->add( YCPString( YUICap_HasFullUtf8Support		), YCPBoolean( app->hasFullUtf8Support()    ) );
+    info_map->add( YCPString( YUICap_HasWidgetStyleSupport      ), YCPBoolean( app->hasWidgetStyleSupport() ) );
     info_map->add( YCPString( YUICap_RichTextSupportsTable	), YCPBoolean( app->richTextSupportsTable() ) );
-    info_map->add( YCPString( YUICap_LeftHandedMouse		), YCPBoolean( app->leftHandedMouse()	) );
+    info_map->add( YCPString( YUICap_LeftHandedMouse		), YCPBoolean( app->leftHandedMouse()	    ) );
     info_map->add( YCPString( YUICap_y2debug			), YCPBoolean( YUILog::debugLoggingEnabled() ) );
 
     return info_map;
@@ -1512,6 +1513,24 @@ YCPValue YCP_UI::AskForSaveFileName( const YCPString & startWith,
 	return YCPString( ret );
 }
 
+
+/**
+ * @builtin AskForWidgetStyle
+ * @short Ask the user what widget style (theme) to use.
+ *
+ * @description
+ * Open a pop-up dialog to let the user select between the available widget
+ * styles (themes). If the UI does not support that, this does nothing.
+ *
+ * Use GetDisplayInfo() and check the HasWidgetStyleSupport capability to check
+ * if the UI supports this.
+ */
+void YCP_UI::AskForWidgetStyle()
+{
+    YUI::app()->askForWidgetStyle();
+}
+
+
 /**
  * @builtin SetFunctionKeys
  * @short Sets the (default) function keys for a number of buttons.
@@ -1634,9 +1653,9 @@ YCPValue YCP_UI::evaluateCallback( const YCPTerm & term, bool to_wfm )
 
 /**
 * @description
-* Opens a context menu when the users right clickes a widget 
-* 
-* 
+* Opens a context menu when the users right clicks a widget
+*
+*
 * Example: <tt>OpenContextMenu( `menu(
 * [ `item(`id(`folder), "&Entry1"  ),
 * `menu( "&Submenu1",
@@ -1646,20 +1665,20 @@ YCPValue YCP_UI::evaluateCallback( const YCPTerm & term, bool to_wfm )
 * "&Entry3"     ) ]) ]  )); </tt>
 *
 * @param itemList list of menu items
-* @return bool  Returns true when the context menu was shown, on error 
+* @return bool  Returns true when the context menu was shown, on error
                 (e.g. not supported by ui) false is returned.
-                
+
 */
 YCPBoolean YCP_UI::OpenContextMenu ( const YCPTerm & term )
 {
     YCPList itemList = term->value(0)->asList();
- 
+
     if ( YUI::app()->openContextMenu( YCPMenuItemParser::parseMenuItemList( itemList ) ) )
 	return YCPBoolean( true );
     else
 	return YCPBoolean( false );
 }
- 
+
 
 /**
  * @builtin SetReleaseNotes

--- a/src/YCP_UI.h
+++ b/src/YCP_UI.h
@@ -53,6 +53,7 @@ public:
     static YCPValue	AskForExistingDirectory		( const YCPString & startDir, const YCPString & headline );
     static YCPValue 	AskForExistingFile		( const YCPString & startDir, const YCPString & filter, const YCPString & headline );
     static YCPValue 	AskForSaveFileName		( const YCPString & startDir, const YCPString & filter, const YCPString & headline );
+    static void         AskForWidgetStyle               ();
     static void 	BusyCursor			();
     static void 	Beep     			();
     static YCPValue 	ChangeWidget			( const YCPValue & widgetId, const YCPValue & property, const YCPValue & new_value );
@@ -85,6 +86,7 @@ public:
 							  const YCPString & screen_map,
 							  const YCPString & unicode_map,
 							  const YCPString & encoding );
+
     static void 	SetKeyboard			();
     static YCPInteger 	RunInTerminal			( const YCPString & module);
     static YCPBoolean 	SetFocus			( const YCPValue & widgetId );
@@ -140,14 +142,14 @@ protected:
     //
     // Data members
     //
-    
+
     /**
      * Queue for synthetic (faked) user input events.
      * Filled with FakeUserInput(), consumed with UserInput() and related.
      **/
     static std::deque<YCPValue> _fakeUserInputQueue;
 
-    
+
 private:
     YCP_UI() {}
     ~YCP_UI() {}

--- a/src/YUINamespace.cc
+++ b/src/YUINamespace.cc
@@ -93,10 +93,10 @@ YUINamespace::SetProductName( const YCPString & name )
 
 YCPValue
 YUINamespace::SetConsoleFont( const YCPString & console_magic,
-		  const YCPString & font,
-		  const YCPString & screen_map,
-		  const YCPString & unicode_map,
-		  const YCPString & encoding )
+                              const YCPString & font,
+                              const YCPString & screen_map,
+                              const YCPString & unicode_map,
+                              const YCPString & encoding )
 {
     if ( YUIComponent::ui() )
 	YCP_UI::SetConsoleFont( console_magic,
@@ -619,6 +619,16 @@ YUINamespace::AskForSaveFileName( const YCPString & startWith, const YCPString &
 	return YCP_UI::AskForSaveFileName( startWith, filter, headline );
     else
 	return YCPVoid();
+}
+
+
+YCPValue
+YUINamespace::AskForWidgetStyle()
+{
+    if ( YUIComponent::ui() )
+	YCP_UI::AskForWidgetStyle();
+
+    return YCPVoid();
 }
 
 

--- a/src/YUINamespace.h
+++ b/src/YUINamespace.h
@@ -301,6 +301,9 @@ public:
     /* TYPEINFO: string (string, string, string) */
     YCPValue AskForSaveFileName( const YCPString & startWith, const YCPString & filter, const YCPString & headline );
 
+    /* TYPEINFO: void () */
+    YCPValue AskForWidgetStyle();
+
     /* TYPEINFO: void (map<any,any>) */
     YCPValue SetFunctionKeys( const YCPMap & new_fkeys );
 


### PR DESCRIPTION
## Trello

https://trello.com/c/joXRejJi/


## Jira

- Epic: https://jira.suse.com/browse/SLE-20547
- Dev: https://jira.suse.com/browse/SLE-20564


## Requested Feature

> The SLE 15 SP3 has a very dark mode, it's sometimes very hard to read during the day. Pop-ups are basically invisible as they surrounding lines are also dark. Modern applications nowadays support a little switch between dark and light theme. And yes, many installations are still done manually.


# Implementation

This adds a new UI built-in `UI.AskForWidgetStyle()` that can be used from Ruby code which opens the same pop-up as the `Shift` `F3` key combination. This can make that feature more discoverable than the key combination.

The capability (if the UI actually supports that) can be queried with `UI.GetDisplayInfo()` and the new `HasWidgetStyleSupport` capability, so the Ruby code can check if the feature should be offered (e.g. in a menu).

# Screenshot

![UI-AskForWidgetStyle](https://user-images.githubusercontent.com/11538225/151987600-369050c0-8ba3-4670-ba0b-b13830e81c92.png)


# Related PR

- https://github.com/libyui/libyui/pull/64
  (needed to get the build checks green)