### PR TITLE
Modernized UI Examples

### DIFF
--- a/examples/Wizard-RelNotes.rb
+++ b/examples/Wizard-RelNotes.rb
@@ -1,0 +1,147 @@
+# encoding: utf-8
+#
+# Wizard example with steps and release notes.
+#
+# Note: Ruby applications are discouraged from using the Wizard widget directly.
+# Use the Wizard module instead.
+#
+
+module Yast
+  class WizardClient < Client
+    include Yast::Logger
+    YAST_ICON = "/usr/share/icons/hicolor/scalable/apps/yast.svg".freeze
+
+    def main
+      Yast.import "UI"
+
+      return unless ensure_wizard_widget
+
+      UI.OpenDialog(Opt(:defaultsize), wizard_dialog)
+      set_up_wizard
+      event_loop
+      UI.CloseDialog
+      nil
+    end
+
+    def event_loop
+      while true
+        event = UI.WaitForEvent
+        log.info("Got event: #{event}")
+        break if event["ID"] == :abort
+
+        display_event(event)
+      end
+    end
+
+    def ensure_wizard_widget
+      return true if UI.HasSpecialWidget(:Wizard)
+
+      msg = "FATAL: This works only with UIs that provide the wizard widget!"
+      log.error(msg)
+      puts(msg)
+      false
+    end
+
+    def wizard_dialog
+      Wizard(
+        Opt(:stepsEnabled),
+        :back, "&Back",
+        :abort, "Ab&ort",
+        :next, "&Next"
+      )
+    end
+
+    def set_up_wizard
+      UI.WizardCommand(term(:SetDialogIcon, YAST_ICON))
+      UI.WizardCommand(term(:SetDialogHeading, "Welcome to the YaST2 installation"))
+      UI.WizardCommand(term(:SetHelpText, help_text))
+      add_wizard_steps
+      add_release_notes
+    end
+
+    def help_text
+      "<p>This is a help text.</p>" +
+      "<p>It should be helpful.</p>" +
+      "<p>If it isn't helpful, it should rather not be called a <i>help text</i>.</p>"
+    end
+
+    def add_wizard_steps
+      UI.WizardCommand(term(:AddStepHeading, "Base Installation"))
+      UI.WizardCommand(term(:AddStep, "Language", "lang"))
+      UI.WizardCommand(term(:AddStep, "Installation Settings", "proposal"))
+      UI.WizardCommand(term(:AddStep, "Perform Installation", "doit"))
+
+      UI.WizardCommand(term(:AddStepHeading, "Configuration"))
+      UI.WizardCommand(term(:AddStep, "Root Password", "root_pw"))
+      UI.WizardCommand(term(:AddStep, "Network", "net"))
+      UI.WizardCommand(term(:AddStep, "Online Update", "you"))
+      UI.WizardCommand(term(:AddStep, "Users", "auth"))
+      UI.WizardCommand(term(:AddStep, "Clean Up", "suse_config"))
+      UI.WizardCommand(term(:AddStep, "Release Notes", "rel_notes"))
+      UI.WizardCommand(term(:AddStep, "Device Configuration", "hw_proposal"))
+      UI.WizardCommand(term(:UpdateSteps))
+
+      UI.WizardCommand(term(:SetCurrentStep, "net"))
+    end
+  end
+
+  def display_event(event)
+    serial = event["EventSerialNo"]
+    type = event["EventType"]
+    id = event["ID"]
+
+    UI.ReplaceWidget(
+      Id(:contents),
+      HVSquash(
+        VBox(
+          Heading("Caught event:"),
+          VSpacing(0.5),
+          Left(Label("Type: #{type}")),
+          Left(Label("ID: #{id}")),
+          Left(Label("Serial No: #{serial}"))
+        )
+      )
+    )
+  end
+
+  def add_release_notes
+    UI.SetReleaseNotes(release_notes_map)
+    UI.WizardCommand(term(:ShowReleaseNotesButton, "Release Notes", "wizard_rel_notes"))
+  end
+
+  def release_notes_map
+    {
+      "SLES" => sles_release_notes,
+      "Foo" => foo_release_notes
+    }
+  end
+
+  def sles_release_notes
+    File.read("./RELEASE-NOTES.en.rtf")
+  end
+
+  def foo_release_notes
+    # Release notes with an external link (bsc#1195158):
+    # A click on the link should not clear the content.
+    notes = <<~EOF
+      <h1><a name="foo">Foo Release Notes</a></h1>
+      <p>Is it a foo? Is it a bar? You decide.</p>
+      <p>No matter if it's foo or bar, it will be good for you!</p>
+      <p>See more at the <a href="https://www.suse.com/">SUSE home page</<a>.</p>
+      <p>And if you click here, the content should not disappear!</p>
+      EOF
+
+    notes += "<br>" * 20
+    # Internal links should work, no matter if they are valid or not.
+    notes += <<~EOF
+      <p><i>
+      Back to the 
+      <a href="#foo">top</a> or 
+      <a href="#anywhere">anywhere</a>
+      </i></p>
+      EOF
+    notes
+  end
+end
+
+Yast::WizardClient.new.main

--- a/examples/Wizard2.rb
+++ b/examples/Wizard2.rb
@@ -1,50 +1,70 @@
 # encoding: utf-8
-
-# Example of using the Wizard widget.
 #
-# Note: YCP applications are discouraged from using the Wizard widget directly.
+# Wizard example with steps.
+#
+# Note: Ruby applications are discouraged from using the Wizard widget directly.
 # Use the Wizard module instead.
+#
+
 module Yast
-  class Wizard2Client < Client
+  class WizardClient < Client
+    include Yast::Logger
+    YAST_ICON = "/usr/share/icons/hicolor/scalable/apps/yast.svg".freeze
+    
     def main
       Yast.import "UI"
-      if !UI.HasSpecialWidget(:Wizard)
-        Builtins.y2error(
-          "This works only with UIs that provide the wizard widget!"
-        )
-        return
+      
+      return unless ensure_wizard_widget
+      
+      UI.OpenDialog(Opt(:defaultsize), wizard_dialog)
+      set_up_wizard
+      event_loop
+      UI.CloseDialog
+      nil
+    end
+
+    def event_loop
+      while true
+        event = UI.WaitForEvent
+        log.info("Got event: #{event}")
+        break if event["ID"] == :abort
+
+        display_event(event)
       end
+    end
 
-      @help_text = "<p>This is a help text.</p>" +
-        "<p>It should be helpful.</p>" +
-        "<p>If it isn't helpful, it should rather not be called a <i>help text</i>.</p>"
+    def ensure_wizard_widget
+      return true if UI.HasSpecialWidget(:Wizard)
 
-      UI.OpenDialog(
-        Opt(:defaultsize),
-        Wizard(
-          Opt(:stepsEnabled),
-          :back,
-          "&Back",
-          :abort,
-          "Ab&ort",
-          :next,
-          "&Next"
-        )
+      msg = "FATAL: This works only with UIs that provide the wizard widget!"
+      log.error(msg)
+      puts(msg)
+      false
+    end
+
+    def wizard_dialog
+      Wizard(
+        Opt(:stepsEnabled),
+        :back, "&Back",
+        :abort, "Ab&ort",
+        :next, "&Next"
       )
+    end
 
-      # UI::DumpWidgetTree();
+    def set_up_wizard
+      UI.WizardCommand(term(:SetDialogIcon, YAST_ICON))
+      UI.WizardCommand(term(:SetDialogHeading, "Welcome to the YaST2 installation"))
+      UI.WizardCommand(term(:SetHelpText, help_text))
+      add_wizard_steps
+    end
 
-      UI.WizardCommand(
-        term(
-          :SetDialogIcon,
-          "/usr/share/YaST2/theme/current/icons/22x22/apps/YaST.png"
-        )
-      )
-      UI.WizardCommand(
-        term(:SetDialogHeading, "Welcome to the YaST2 installation")
-      )
-      UI.WizardCommand(term(:SetHelpText, @help_text))
+    def help_text
+      "<p>This is a help text.</p>" +
+      "<p>It should be helpful.</p>" +
+      "<p>If it isn't helpful, it should rather not be called a <i>help text</i>.</p>"
+    end
 
+    def add_wizard_steps
       UI.WizardCommand(term(:AddStepHeading, "Base Installation"))
       UI.WizardCommand(term(:AddStep, "Language", "lang"))
       UI.WizardCommand(term(:AddStep, "Installation Settings", "proposal"))
@@ -59,44 +79,29 @@ module Yast
       UI.WizardCommand(term(:AddStep, "Release Notes", "rel_notes"))
       UI.WizardCommand(term(:AddStep, "Device Configuration", "hw_proposal"))
       UI.WizardCommand(term(:UpdateSteps))
-
-      if false
-        UI.WizardCommand(term(:SetAbortButtonLabel, "&Cancel"))
-        UI.WizardCommand(term(:SetBackButtonLabel, ""))
-        UI.WizardCommand(term(:SetNextButtonLabel, "&Accept"))
-      end
-
+      
       UI.WizardCommand(term(:SetCurrentStep, "net"))
-
-      while true
-        @event = UI.WaitForEvent
-
-        Builtins.y2milestone("Got event: %1", @event)
-
-        break if Ops.get(@event, "ID") == :abort
-
-        @serial = Ops.get_integer(@event, "EventSerialNo", 0)
-        @type = Ops.get_string(@event, "EventType", "")
-        @id = Ops.get_symbol(@event, "ID", :nil)
-
-
-        UI.ReplaceWidget(
-          Id(:contents),
-          VBox(
-            Heading("Caught event:"),
-            VSpacing(0.5),
-            Label(Ops.add("Serial No: ", Builtins.tostring(@serial))),
-            Label(Ops.add("Type: ", @type)),
-            Label(Ops.add("ID: ", Builtins.tostring(@id)))
-          )
-        )
-      end
-
-      UI.CloseDialog
-
-      nil
     end
+  end
+
+  def display_event(event)
+    serial = event["EventSerialNo"]
+    type = event["EventType"]
+    id = event["ID"]
+
+    UI.ReplaceWidget(
+      Id(:contents),
+      HVSquash(
+        VBox(
+          Heading("Caught event:"),
+          VSpacing(0.5),
+          Left(Label("Type: #{type}")),
+          Left(Label("ID: #{id}")),
+          Left(Label("Serial No: #{serial}"))
+        )
+      )
+    )
   end
 end
 
-Yast::Wizard2Client.new.main
+Yast::WizardClient.new.main

--- a/package/yast2-ycp-ui-bindings.changes
+++ b/package/yast2-ycp-ui-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 15 11:45:57 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Modernized the Wizard2.rb example to use real Ruby
+- Added a new example Wizard-RelNotes.rb to test the release notes
+  viewer that is built into the YQWizard (bsc#1195158)
+
+-------------------------------------------------------------------
 Tue Feb  1 15:38:55 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Added UI.AskForWidgetStyle() (jsc#SLE-20564)


### PR DESCRIPTION
- Modernized the Wizard2.rb example to use real Ruby, getting rid of all the YCP Zombies
- Added a new example to test and showcase the release notes button in the YQWizard and the YQWizard's built-in release notes viewer.
  This is a test case for [bsc#1195158](https://bugzilla.suse.com/show_bug.cgi?id=1195158):
  A click on an external hyperlink in the release notes should _not_ clear the content of the release notes viewer.

![Wizard-RelNotes](https://user-images.githubusercontent.com/11538225/158372550-cb3df490-c3dd-4167-83c9-b114525cd849.png)

## No Version Bump?

No, no version bump; we don't need to submit this to SLE-15 SP4. It's just UI examples, no production code. If there is a real code change to the UI bindings some time in the future, that will be soon enough.